### PR TITLE
Merging temporary `devenv-next` into `devenv` where it's supposed to be

### DIFF
--- a/Location.js
+++ b/Location.js
@@ -1,21 +1,22 @@
 class Location {
+    
     constructor(locationid, displayName, deviceid, phonenumber, detectionzoneMin, detectionzoneMax, sensitivity, led, noisemap, movThreshold, durationThreshold, stillThreshold, rpmThreshold, xethruSentAlerts, xethruHeartbeatNumber, doorCoreId, radarCoreId) {
-        this.locationid = locationid,
-        this.displayName = displayName,
-        this.deviceid = deviceid,
-        this.phonenumber = phonenumber,
-        this.detectionzoneMin = detectionzoneMin,
-        this.detectionzoneMax = detectionzoneMax,
-        this.sensitivity = sensitivity,
-        this.led = led,
-        this.noisemap = noisemap,
-        this.movThreshold = movThreshold,
-        this.durationThreshold = durationThreshold,
-        this.stillThreshold = stillThreshold,
-        this.rpmThreshold = rpmThreshold,
-        this.xethruSentAlerts = xethruSentAlerts,
-        this.xethruHeartbeatNumber = xethruHeartbeatNumber,
-        this.doorCoreId = doorCoreId,
+        this.locationid = locationid
+        this.displayName = displayName
+        this.deviceid = deviceid
+        this.phonenumber = phonenumber
+        this.detectionzoneMin = detectionzoneMin
+        this.detectionzoneMax = detectionzoneMax
+        this.sensitivity = sensitivity
+        this.led = led
+        this.noisemap = noisemap
+        this.movThreshold = movThreshold
+        this.durationThreshold = durationThreshold
+        this.stillThreshold = stillThreshold
+        this.rpmThreshold = rpmThreshold
+        this.xethruSentAlerts = xethruSentAlerts
+        this.xethruHeartbeatNumber = xethruHeartbeatNumber
+        this.doorCoreId = doorCoreId
         this.radarCoreId = radarCoreId
     }
 }

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install
 npm run test
 ```
 
-The ests run automatically on Travis on every push to GitHub and every time a pull request is created.
+The tests run automatically on Travis on every push to GitHub and every time a pull request is created.
 
 
 # Dev or Prod Deployment
@@ -41,9 +41,9 @@ These steps need to be re-run anytime you change target deployment environment.
 1. Copy public key from the "ODetect Credentials" vault in 1Password into your local
 `BraveSensor-Server/smartthings_rsa.pub` file
 
-   - If you are deploying to **dev**, copy the value of `Dev - ODetect SmartThings Automation Public Key`
+   - If you are deploying to **dev**, copy the value of `Dev - BraveSensor SmartThings Automation Public Key`
 
-   - If you are deploying to **prod**, copy the value of `Prod - ODetect2 SmartThings Automation Public Key`
+   - If you are deploying to **prod**, copy the value of `Prod - BraveSensor2 SmartThings Automation Public Key`
 
 
 ### .env files

--- a/Session.js
+++ b/Session.js
@@ -1,18 +1,18 @@
 class Session {
 
     constructor(locationid, startTime, endTime, odFlag, state, phonenumber, notes, incidentType, sessionid, duration, stillCounter, chatbotState, alertReason) {
-        this.locationid = locationid,
-        this.startTime = startTime,
-        this.endTime = endTime,
-        this.odFlag = odFlag,
-        this.state = state,
-        this.phonenumber = phonenumber,
-        this.notes = notes,
-        this.incidentType = incidentType,
-        this.sessionid = sessionid,
-        this.duration = duration,
-        this.stillCounter = stillCounter,
-        this.chatbotState = chatbotState,
+        this.locationid = locationid
+        this.startTime = startTime
+        this.endTime = endTime
+        this.odFlag = odFlag
+        this.state = state
+        this.phonenumber = phonenumber
+        this.notes = notes
+        this.incidentType = incidentType
+        this.sessionid = sessionid
+        this.duration = duration
+        this.stillCounter = stillCounter
+        this.chatbotState = chatbotState
         this.alertReason = alertReason
     }
     

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -80,7 +80,7 @@ async function im21Door(door_coreID, signal){
 }
 
 
-describe('ODetect server', () => {
+describe('Brave Sensor server', () => {
 
     after(async function() {
         await sleep(3000)


### PR DESCRIPTION
`devenv-next` was there just while we were waiting for v1.2.0 to be deployed.