### PR TITLE
Tell Helm to get the PG_DATABASE value from the secrets file

### DIFF
--- a/sensor-helm-chart/templates/sensor-deployment.yaml
+++ b/sensor-helm-chart/templates/sensor-deployment.yaml
@@ -60,6 +60,11 @@ spec:
               secretKeyRef:
                 name: {{.Values.secretName}}
                 key: PG_USER
+          - name: PG_DATABASE
+            valueFrom:
+              secretKeyRef:
+                name: {{.Values.secretName}}
+                key: PG_DATABASE
           - name: PG_PORT
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
@mariocimet This is what the problem was yesterday. It seems as though it's OK to build with a `.env` in my local, as long as all the environment variables are declared in the deployment.

Maybe we also need a section on updating environment variables since it's now a number of steps...
- Updating your local `.env`
- Letting people know that it's changed
- Updating the `*.env` files on ODetect Admin
- Updating the `sensor-*` secrets on ODetect Admin
- Updating `.travis.yml`
... is there anything else?