### PR TITLE
Saving IM21 request control field for debugging door sensor issues (CU-n70k94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ the code was deployed.
 ### Added
 - Script, endpoints, and instructions for smoke tests (CU-kcxndt)
 - Update to use Brave-wide linting standard (CU-kcxpaw)
+- Saving control field in door sensor requests (CU-n70k94)
 
 ### Changed
 - checkHeartbeat to run every 15 seconds to fix lack of alerts when sensors go down (CU-p34wcw)

--- a/db/redis.js
+++ b/db/redis.js
@@ -53,10 +53,10 @@ async function disconnect() {
   await client.disconnect()
 }
 
-async function addIM21DoorSensorData(locationid, doorSignal) {
+async function addIM21DoorSensorData(locationid, doorSignal, control) {
   // eslint-disable-next-line eqeqeq
   if (doorSignal == SESSIONSTATE_DOOR.CLOSED || doorSignal == SESSIONSTATE_DOOR.OPEN) {
-    await client.xadd(`door:${locationid}`, 'MAXLEN', '~', '10000', '*', 'signal', doorSignal)
+    await client.xadd(`door:${locationid}`, 'MAXLEN', '~', '10000', '*', 'signal', doorSignal, 'control', control)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -437,6 +437,7 @@ app.post('/api/door', Validator.body(['coreid', 'data']).exists(), async (reques
       } else {
         const message = JSON.parse(request.body.data)
         const signal = message.data
+        const control = message.control
         let doorSignal
         if (signal === IM21_DOOR_STATUS.OPEN) {
           doorSignal = SESSIONSTATE_DOOR.OPEN
@@ -446,12 +447,9 @@ app.post('/api/door', Validator.body(['coreid', 'data']).exists(), async (reques
           doorSignal = 'LowBatt'
         } else if (signal === IM21_DOOR_STATUS.HEARTBEAT_OPEN || signal === IM21_DOOR_STATUS.HEARTBEAT_CLOSED) {
           doorSignal = 'HeartBeat'
-        } else {
-          helpers.log(`Bad request, door status is undefined`)
-          response.status(400).send()
         }
 
-        await redis.addIM21DoorSensorData(locationid, doorSignal)
+        await redis.addIM21DoorSensorData(locationid, doorSignal, control)
         await handleSensorRequest(locationid)
         response.status(200).json('OK')
       }


### PR DESCRIPTION
Why?

We are having trouble with false positives at Covenant_2 aka 'Youth #111' and suspect that door sensor problems are to blame. Tracking the "control bytes" can help us diagnose it. The control number should increase by one with each door event, so tracking these would reveal if we're missing any requests server side (as opposed to the sensor or argon itself missing events).

See our conversation at https://bravely.slack.com/archives/C0153GVBNGG/p1614800310001600