### PR TITLE
Use Travis to push Docker containers to DO (CU-mrxren)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,56 +1,67 @@
 dist: xenial
 
-matrix:
+language: node_js
+node_js: 'node' # node version specified in .nvmrc
+
+# install dependencies
+install:
+  - npm ci
+  - npm install pg@latest
+
+# install Redis
+services:
+  - redis-server
+
+addons:
+  # install PostgreSQL
+  postgresql: '12'
+  apt:
+    packages:
+      - postgresql-12
+      - postgresql-client-12
+  # install Digital Ocean API CLI tool
+  snaps:
+    - doctl
+
+# setup environment variables because Travis doesn't have a .env file
+env:
+  global:
+    - WEB_USERNAME_TEST=TravisDashboardUsername
+    - PASSWORD_TEST=TravisDashboardPassword
+    - SECRET_TEST=TravisCookieSecret
+    - PG_USER_TEST=brave
+    - PG_DATABASE_TEST=brave
+    - PG_PASSWORD_TEST=travispassword
+    - PG_PORT_TEST=5433
+    - PG_HOST_TEST=localhost
+    - PG_USER=brave
+    - PG_DATABASE=brave
+    - PG_PASSWORD=travispassword
+    - PG_PORT=5433
+    - PG_HOST=localhost
+    - REDIS_CLUSTER_IP_TEST=localhost
+    # TWILIO_SID_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
+    - secure: 'T4IjkoXVMFLcbq7livJ6HxATgk/q2znD4+BdFPn8cuNRc6QzBiNR7AZWoyhRrXqvBv3H3Mq5MIGPmYUW2HRXrihq3VLcp1ZRejXjv3CKqg518yi4JHax7hYesRUE9RoU8SXpOvEQknV9LnNbL030cL7kef1MLd+LepRMvo6B/+3/HuhjZHAmGOj93n8r7Ee1u/OzQDajXKbK0NhsE5HSMsKhwDQe+yyWZKerK1FDx35U4kjmj4kaafNYoLUNwr5S64avBI7kaA45TQ4h4BgPfHVLNwpI+9kVQpCc+wHnEVDd6FzAb3fp8PtYrT1W1hIe9A/+emX2QuMFtHHB6+PNUdPY4q+Wu6RJePcKVw9bWbsMFoAOJ8ZOyL7n/WxfP06FtLx9g8X/FyCNnbtKJlgd+NiIvV45s8QW6tG7/df7m2/FbmENl6++2JsV7HnVyuEITOe8wx/Evnr9Hzlh8zvDfQ3qY8Gb/BusQ7eSeaq/08yE+pZyTDCCh1lyfxaGBC1C6QV5QMwEHPq3U70MdhiXoSKV8Za2GhW96d5dA75yPPqqhc1/MDXZvOUAk/nNs/mzYhlQg2XbR8VML7aSTtP+zwX57kt/5DpXibIPl3wAnXMNhVNPYT3xPnzPRSEzUNAJI/f9qwOTK9eEzspumdqUAxkss5YoE5VWDMHPC4f3Hhk='
+    # TWILIO_TOKEN_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
+    - secure: 'YXELSMATbhbhG7UhAq0hCfnrHFC0BPtHTE3yv/7NWe/fsw2uPz8QtSLYUhQ2+hMrCSqP1Z8e4l4J8w3tIZA7vpT6W3kHIT19HGjATs0GQEjVynQfPbNitb5WJu1AZmEuoGlbPx85hC8pHNtW0Q15qM3OWh4M9i0sk3XdQ5QRZwlAsdicbgvXRLds3W71Pi/FiTuVCbWtW7la3UMo0YwZTYXECLr4OYkmBsDTKvCpxRRLmgNE+nj/cIYAVDo+/K5sCdi+1sHLtFrqBogKQyiT0oQe1rjNQ03aA4+gSs1sFNJGPoff7jyqSRqAA/IamDUPbqqcOFhUEhskxNa0VBG7CVasVAIsIIZg0wnbR+nMhQm0ZeZBInXZKprtBV0aag10uN+p/lZDwwQHu0RmPv+6vzdJ8Q5AQAPOL6c272YOXYxcA2ft7jRM3S+i48w8qfFWuP4pCcUW4BrTI7snJe2MQcNCT9S2GeNv2EVFr1Or3gFN+xTMQSKXApaWvV4IE2ETc9AtJ3VjSUltqAGyeaBqDoisO6w4t0o1iyRJUkhmCt+TbYQ1R4ks6eDYstSmDQVa2UNh4DLvQhmv5u+78s9B0+SN5fEIx3d9Pl7XsYZQR/eKXzaAEFqfL/M9wUs2XX3oKwzcnsfzQUZDqgzxp3DccNUGSlo4MNTJ5hTgPRBH5Zs='
+    - PGVER=12
+    - PGPORT=5433
+    # DIGITALOCEAN_ACCESS_TOKEN (from the service user's account and https://cloud.digitalocean.com/account/api/tokens)
+    - secure: 'WTkzux5DqTQ8NZJ+SENyl5PB0W7+Tg1m1hSLZ828zmG2vY/ae81x4e8719APZUnWcRmnOoFp/PJfKQ/+23F9n2UZCWsn8TupgVApCd7mXb9uTsx9l0slbrD3Xcaem0Cwa65QRjMYaVm/ywLoK3GS+CqA8VtkMBQCHIWYopWaZZyT62KS+PELX4xhM33BW7qLnEONsUaHPefECj+8gIxrULVdkvVxN9lyzH2BBX/MlJMg+dtl6+zO3VcckQJsEZEpFzGK7Lq9t03TYjPZALnaQncA/7xOtW20TslTH+XghaZ7PLVLlY36PCgj+a6DlLuJJ9zxaLHdvFFKY8SN6BKgJh9oJ8sHW2PJnuxZQgB+5SN0W5I2AfnlwzlZcnyKtQgwTQSC3wjorDAbp4OB0tRevBmyQDhGc96KsYam0fP70MtyCTxVwth7TCaUWznXwDhfStKOHuvwrFF0g1dfhSRKEZbLP4LcFljNYFpDcEMKrQKAPXhHSNpJUTyxgy3xlrYKdYVzk9SRkOZWTw0pDHkL3Ya1nHEFMs3SAo9wZ8o6KmcZdlXjamRo9SpossjCykTosuUegQ72IXgZ25gB7Q4trz+liqp/HKBgZpFNmR0V8gAXPM4cxyBZBo7jMxdIRWJ513C1EcY7HVF+zs6bOlivxzZ3tbOWLvZ4EBJVgcT2Pi0='
+
+before_script:
+  - bash setup_postgresql_local.sh
+
+jobs:
   include:
-    - name: Server
-      language: node_js
-      node_js: "node"         # node version specified in .nvmrc
-
-      # install dependencies
-      install:
-        - npm ci
-        - npm install pg@latest
-
-      # install Redis
-      services:
-        - redis-server 
-
-      addons:
-        # install PostgreSQL
-        postgresql: "12"
-        apt:
-          packages:
-          - postgresql-12
-          - postgresql-client-12
-
-      # setup environment variables because Travis doesn't have a .env file
-      env:
-        - WEB_USERNAME_TEST=TravisDashboardUsername
-        - PASSWORD_TEST=TravisDashboardPassword
-        - SECRET_TEST=TravisCookieSecret
-        - PG_USER_TEST=brave
-        - PG_DATABASE_TEST=brave
-        - PG_PASSWORD_TEST=travispassword
-        - PG_PORT_TEST=5433
-        - PG_HOST_TEST=localhost
-        - PG_USER=brave
-        - PG_DATABASE=brave
-        - PG_PASSWORD=travispassword
-        - PG_PORT=5433
-        - PG_HOST=localhost
-        - REDIS_CLUSTER_IP_TEST=localhost
-        # TWILIO_SID_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
-        - secure: "T4IjkoXVMFLcbq7livJ6HxATgk/q2znD4+BdFPn8cuNRc6QzBiNR7AZWoyhRrXqvBv3H3Mq5MIGPmYUW2HRXrihq3VLcp1ZRejXjv3CKqg518yi4JHax7hYesRUE9RoU8SXpOvEQknV9LnNbL030cL7kef1MLd+LepRMvo6B/+3/HuhjZHAmGOj93n8r7Ee1u/OzQDajXKbK0NhsE5HSMsKhwDQe+yyWZKerK1FDx35U4kjmj4kaafNYoLUNwr5S64avBI7kaA45TQ4h4BgPfHVLNwpI+9kVQpCc+wHnEVDd6FzAb3fp8PtYrT1W1hIe9A/+emX2QuMFtHHB6+PNUdPY4q+Wu6RJePcKVw9bWbsMFoAOJ8ZOyL7n/WxfP06FtLx9g8X/FyCNnbtKJlgd+NiIvV45s8QW6tG7/df7m2/FbmENl6++2JsV7HnVyuEITOe8wx/Evnr9Hzlh8zvDfQ3qY8Gb/BusQ7eSeaq/08yE+pZyTDCCh1lyfxaGBC1C6QV5QMwEHPq3U70MdhiXoSKV8Za2GhW96d5dA75yPPqqhc1/MDXZvOUAk/nNs/mzYhlQg2XbR8VML7aSTtP+zwX57kt/5DpXibIPl3wAnXMNhVNPYT3xPnzPRSEzUNAJI/f9qwOTK9eEzspumdqUAxkss5YoE5VWDMHPC4f3Hhk="
-        # TWILIO_TOKEN_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
-        - secure: "YXELSMATbhbhG7UhAq0hCfnrHFC0BPtHTE3yv/7NWe/fsw2uPz8QtSLYUhQ2+hMrCSqP1Z8e4l4J8w3tIZA7vpT6W3kHIT19HGjATs0GQEjVynQfPbNitb5WJu1AZmEuoGlbPx85hC8pHNtW0Q15qM3OWh4M9i0sk3XdQ5QRZwlAsdicbgvXRLds3W71Pi/FiTuVCbWtW7la3UMo0YwZTYXECLr4OYkmBsDTKvCpxRRLmgNE+nj/cIYAVDo+/K5sCdi+1sHLtFrqBogKQyiT0oQe1rjNQ03aA4+gSs1sFNJGPoff7jyqSRqAA/IamDUPbqqcOFhUEhskxNa0VBG7CVasVAIsIIZg0wnbR+nMhQm0ZeZBInXZKprtBV0aag10uN+p/lZDwwQHu0RmPv+6vzdJ8Q5AQAPOL6c272YOXYxcA2ft7jRM3S+i48w8qfFWuP4pCcUW4BrTI7snJe2MQcNCT9S2GeNv2EVFr1Or3gFN+xTMQSKXApaWvV4IE2ETc9AtJ3VjSUltqAGyeaBqDoisO6w4t0o1iyRJUkhmCt+TbYQ1R4ks6eDYstSmDQVa2UNh4DLvQhmv5u+78s9B0+SN5fEIx3d9Pl7XsYZQR/eKXzaAEFqfL/M9wUs2XX3oKwzcnsfzQUZDqgzxp3DccNUGSlo4MNTJ5hTgPRBH5Zs="
-        - PGVER=12
-        - PGPORT=5433
-
-      # setup database and create dummy public key for smartthings integration
-      before_script:
-        - bash setup_postgresql_local.sh
-
-      # run unit tests, integration tests, and linter
+    # Run linting, unit tests, and integration tests
+    - stage: test
       script:
         - npm run lint
         - sudo env "PATH=$PATH" npm test
+    # If all the test stage passes, then pushes the Docker container to DO
+    - stage: 'push container'
+      script:
+        - doctl auth init --access-token $DIGITALOCEAN_ACCESS_TOKEN
+        - sudo snap connect doctl:dot-docker
+        - ./build.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -9,29 +10,40 @@ was committed to the `master` branch. This is not necessarily the date that
 the code was deployed.
 
 ## [Unreleased]
+
 ### Added
+
 - Script, endpoints, and instructions for smoke tests (CU-kcxndt)
 - Update to use Brave-wide linting standard (CU-kcxpaw)
 - Saving control field in door sensor requests (CU-n70k94)
+- Automatic uploading of Docker containers to Digital Ocean using Travis (CU-mrxren)
 
 ### Changed
+
 - checkHeartbeat to run every 15 seconds to fix lack of alerts when sensors go down (CU-p34wcw)
 
 ### Removed
+
 - Smartapp integration, dependencies, and tests (CU-p980za)
 
 ### Security
+
 - Updated to latest version of minimist (CU-kry4g7)
 
 ## [2.0.0] - 2021-03-08
+
 ### Added
+
 - Express validations for endpoints (CU-hx0jjc)
 
 ### Changed
+
 - Use Brave Alert Lib for Twilio communication with the Responder (CU-bar1zy)
 
 ## [1.2.0] - 2021-02-12
+
 ### Added
+
 - New mustache frontend (CU-dwr2xb)
 - Script which runs all database migrations
 - Integration tests (CU-gcuxtz)
@@ -45,16 +57,19 @@ the code was deployed.
 - Helm chart (CU-kcxn8q)
 
 ### Fixed
+
 - Bug in calculating session duration (CU-gcuxtz)
 - Session creation concurrency bug (CU-gcuxtz)
-- Alert reason attribution bug  (CU-gcuxtz)
+- Alert reason attribution bug (CU-gcuxtz)
 - Session creation when there is no previous session for a location (CU-gcuxtz)
 - Update location_human in fallback message to display_name to fix display issue (CU-mgz8vq)
 
 ### Security
+
 - Removed all references to axios < v0.21.1 (CU-j6yuzk)
 
 ### Removed
+
 - Old angular frontend (CU-dwr2xb)
 - Unused PostgreSQL functions
 - Unused PostgreSQL tables
@@ -62,36 +77,43 @@ the code was deployed.
 - Unused and deprecated load testing scripts
 
 ## [1.1] - 2020-10-07
+
 ### Added
+
 - Sentry tracking of runtime errors
 - Alert reason included in the initial chatbot message (stillness, duration)
 - Fallback alert functionality added
 - Fallback alerts sent with human readable bathroom text
 
 ## Fixed
+
 - Heartbeat alert implementation
-- Chatbot interference when a single responder phone is dealing with simultaneous sessions from multiple bathrooms 
+- Chatbot interference when a single responder phone is dealing with simultaneous sessions from multiple bathrooms
 
 ## [1.1-alpha] - 2020-09-23
+
 ### Added
+
 - Sentry tracking of runtime errors
 - Alert reason included in the initial chatbot message (stillness, duration)
-- Fallback alert functionality added 
-- Fallback alerts sent with human readable bathroom text 
+- Fallback alert functionality added
+- Fallback alerts sent with human readable bathroom text
 
 ### Fixed
+
 - Heartbeat alert implementation
 
 ## [1.0] - 2020-08-28
+
 ### Added
+
 - Dockerized ODetect application w/ Dockerfile
 - Redis used as in-memory database for sensor data
 - Kubernetes deployment of ODetect app, redis server
 - Battery life monitoring for Door sensors
 - Replay Data functionality to simulate historical data and test new state machine candidates
 
-
-[Unreleased]: https://github.com/bravetechnologycoop/BraveSensor-Server/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/bravetechnologycoop/BraveSensor-Server/compare/v2.0.0...HEAD
 [2.0.0]: https://github.com/bravetechnologycoop/BraveSensor-Server/compare/v1.2.0...v2.0.0
 [1.2.0]: https://github.com/bravetechnologycoop/BraveSensor-Server/compare/v1.1...v1.2.0
 [1.1]: https://github.com/bravetechnologycoop/BraveSensor-Server/compare/v1.1-alpha...v1.1

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # BraveSensor-Server
+
 [![Build Status](https://travis-ci.com/bravetechnologycoop/BraveSensor-Server.svg?branch=master)](https://travis-ci.com/bravetechnologycoop/BraveSensor-Server)
 
 # How to release a new version of BraveSensor-Server
@@ -7,29 +8,27 @@
 
 1. on your local machine, in the `BraveSensor-Server` repository:
 
-    1. pull the latest code ready for release: `git checkout devenv && git pull origin devenv`
-    
-    1. run `npm ci`
+   1. pull the latest code ready for release: `git checkout devenv && git pull origin devenv`
 
-    1. decide on an appropriate version number for the new version
+   1. decide on an appropriate version number for the new version
 
-    1. update CHANGELOG.md by moving everything in `Unreleased` to a section for the new version
-    
-    1. Run the `./build.sh` script. Note the tag of the new image. See the section on [building and pushing a new container](#build-and-push-a-new-container) for more details about this step.
+   1. update `CHANGELOG.md` by moving everything in `Unreleased` to a section for the new version
 
-    1. `cd` into the `~/BraveSensor-Server/sensor-helm-chart` directory
+   1. `cd` into the `~/BraveSensor-Server/sensor-helm-chart` directory
 
-        1. Update Chart.yaml with a new `version` and new `appVersion`, if applicable
+      1. Update `Chart.yaml` with a new `version` and new `appVersion`, if applicable
 
-        1. Update values.yaml by putting the tag of your new container image in the `tag` field of `image`
+      1. Run `git log -1 --format=%h` to get the container image tag
 
-    1. make a new commit directly on `devenv` which updates the changelog and helm chart
-    
-    1. tag the new commit - for example, if the version number is v1.0.0, use `git tag v1.0.0`
+      1. Update `values.yaml` by putting the tag of your new container image in the `tag` field of `image`
 
-    1. push the new version to GitHub: `git push origin devenv --tags`
+   1. make a new commit directly on `devenv` which updates the changelog and helm chart
 
-    1. update the `master` branch: `git checkout master && git merge devenv && git push origin master`
+   1. tag the new commit - for example, if the version number is v1.0.0, use `git tag v1.0.0`
+
+   1. push the new version to GitHub: `git push origin devenv --tags`
+
+   1. update the `master` branch: `git checkout master && git merge devenv && git push origin master`
 
 ## 2. Database changes
 
@@ -38,15 +37,18 @@ If your changes involve changes to the database schema, you'll need to run your 
 **If the database changes are breaking, think carefully about how to do this. It may be preferable to briefly shut down the server rather than risk undefined behavior from changing the database schema before changing the code that's running**
 
 ## 3. Environment Variable changes
+
 We deploy BraveSensor-Server onto a [Kubernetes](https://kubernetes.io/docs/home/) cluster as our production environment. On the cluster, environment variables are handled within `secret` resources. You can access the list of secrets on the cluster by running the command:
 `kubectl get secrets`
 
 ### Creating a secret from a .env file
+
 To create a secret from a .env file, run the following command:
 
 `kubectl create secret generic <your-secret-name> --from-env-file=<path-to-env-file>`
 
 ### Altering a secret values after it's been created
+
 If there are any changes to environment variables values, the corresponding Kubernetes secret objects must be changed too.
 
 To update a Kubernetes secret use the command:
@@ -59,6 +61,7 @@ The values displayed will be encoded in base64, and new or altered values must a
 A easier option is to delete the secret and re-create a new secret from scratch using the method described above for [creating a sensor from an env file](#creating-a-secret-from-a-.env-file). This is safe to do and will not affect running pods.
 
 ### Altering a secret's schema
+
 If there are changes to the schema of the environment variables (like the addition or deletion of a key) this change must be reflected in the env variables section of `BraveSensor-Server/sensor-helm-chart/templates/sensor-deployment.yaml`, in addition to changing the Kubernetes secret as described above.
 
 ## 4. Deploy changes to the Kubernetes Cluster
@@ -95,18 +98,20 @@ We use [helm](https://helm.sh/docs/) to manage our deployments. Helm allows us t
 
 1. Run the command `helm upgrade dev --set secretName=sensor-dev --set image.tag=<image tag you want to deploy> sensor-helm-chart`
 
-# Build and push a new container
+# Build and push a new container manually
+
+Note that a new container is built and pushed automatically by Travis each time there is a successful build.
 
 1. Install Docker locally (https://docs.docker.com/get-docker/ and, if you are running Linux,
-https://docs.docker.com/engine/install/linux-postinstall/)
+   https://docs.docker.com/engine/install/linux-postinstall/)
 
 1. Install and configure `doctl` with your API token (https://www.digitalocean.com/docs/apis-clis/doctl/how-to/install/)
 
 1. Build the Docker image, tag it, and push it to the registry by running
 
-    ```
-    ./build.sh
-    ```
+   ```
+   ./build.sh
+   ```
 
 ## Running Smoke Tests on the Kubernetes Cluster
 
@@ -120,19 +125,20 @@ The twilio number must be a valid number for the account, and must have its SMS 
 
 The script will take a few minutes to conclude. The expected behavior is for a location to be created, and for two sessions to be started - one which closes without generating an alert, and one which results in a 'Stillness' alert to the phone number provided. These two sessions should also be reflected in the frontend dashboard. If you do not answer the alert on your phone, you should notice a notification about a session being restarted. If you do, you should complete the chatbot flow.
 
-You can get further details about the behavior of the build by watching logs for the application with: 
+You can get further details about the behavior of the build by watching logs for the application with:
 `kubectl logs -f deployment/staging-sensor-server`
-and by watching the behavior of redis with: 
+and by watching the behavior of redis with:
 `kubectl exec deploy/redis-dev redis-cli monitor`
-
 
 # Local Development
 
 ## Dependencies
+
 1. Dowload and install [redis version 6](https://redis.io/download)
 1. Download and install [PostgreSQL version 12](https://www.postgresql.org/download/)
 
 Alternately, you have the option of installing these dependencies as docker containers
+
 1. Redis: https://hub.docker.com/_/redis
 1. PostgreSQL: https://hub.docker.com/_/postgres
 
@@ -149,12 +155,14 @@ To do this, cd into the BraveSensor-Server directory and run the following comma
 ```
 sudo PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> setup_postgresql_local.sh
 ```
+
 ## Tests
 
 Unit tests are written using the [Mocha](https://mochajs.org/) JS test framework
 and the [Chai](https://www.chaijs.com/) assertion library.
 
 To run the tests locally:
+
 ```
 npm install
 npm run test
@@ -166,9 +174,22 @@ The tests run automatically on Travis on every push to GitHub and every time a p
 
 Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables
 
-1. Download the Travis CLI `brew install travis` or `gem install travis`
+1. Download the Travis CLI `gem install travis`
 
 1. cd to anywhere in this repo
+
+1. temporarily create a personal access token on GitHub https://github.com/settings/tokens with the following permissions:
+
+   - `repo`
+   - `read:packages`
+   - `read:org`
+   - `read:public_key`
+   - `read:repo_hook`
+   - `user`
+   - `read:discussion`
+   - `read:enterprise`
+
+1. login using `travis login --pro --github-token <token from github>`
 
 1. For a given `VAR_NAME` that you want to have value `secret_value`, run
    `travis encrypt --pro VAR_NAME=secret_value`
@@ -177,17 +198,19 @@ Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-env
 
 1. Copy the encrypted variable into `.travis.yml`
 
+1. Delete your personal access token from GitHub
 
 # ODetect Admin Server
 
 The ODetect Admin server is used for both **dev** and **prod**.
 
 To ssh onto the `odetect-admin` server
+
 ```
 ssh brave@odetect-admin.brave.coop
 ```
 
-The `sudo` password is on 1Password --> ODetect Credentials --> Login - odetect-admin 
+The `sudo` password is on 1Password --> ODetect Credentials --> Login - odetect-admin
 (cluster management) server.
 
 ## Adding public keys to the admin server
@@ -204,11 +227,10 @@ Access is restricted to machines whose public key has been added to the server's
 
 The PostgreSQL DB connection parameters are required for the application to open a connection to the database. We primarily use the following databases, although you are free to create new ones for development purposes
 
-| Environment           | User    | Database Name       |
-|-----------------------|---------|---------------------|
-| Production | doadmin | backend-replacement |
-| Development | bravetest | bravetest        |
-
+| Environment | User      | Database Name       |
+| ----------- | --------- | ------------------- |
+| Production  | doadmin   | backend-replacement |
+| Development | bravetest | bravetest           |
 
 To access a database shell
 
@@ -218,12 +240,12 @@ To access a database shell
 
 1. In the Connection Details box:
 
-    1. In the "Connection parameters" dropdown, select "Flags"
+   1. In the "Connection parameters" dropdown, select "Flags"
 
-    1. In the "User" dropdown, select the user for your desired deployment environment
+   1. In the "User" dropdown, select the user for your desired deployment environment
 
-    1. In the "Database/Pool" dropdown, select the database name for your desired deployment
-    environment, click the 'Copy' button below, and paste the result into your terminal to access the shell
+   1. In the "Database/Pool" dropdown, select the database name for your desired deployment
+      environment, click the 'Copy' button below, and paste the result into your terminal to access the shell
 
 ## Adding a new Database migration script
 
@@ -236,18 +258,19 @@ This strategy assumes that each migration script in the `db` directory has a u
 ## Deploying the migration scripts
 
 1. In the BraveSensor-Server directory, run the following command
-    ```
-    
-    PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> setup_postgresql.sh
-    ```
+
+   ```
+
+   PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> setup_postgresql.sh
+   ```
 
 ## Viewing which migration scripts have been run and when
 
 1. Copy the "Flag" connection details from Digital Ocean for the DB you want to check
 
 1. Run
-    ``` postgres
-    SELECT *
-    FROM migrations
-    ORDER BY id;
-    ```
+   ```postgres
+   SELECT *
+   FROM migrations
+   ORDER BY id;
+   ```


### PR DESCRIPTION
- This will ensure that our images are built in a clean and
  consistent environemnt. No chance to anything weird getting
  bundled in from our local dev environments

- Also used the prettier format for the README and CHANGELOG. Because of this, you might want to turn on "Hide whitespace changes" in order to see what really changed in thie PR.

- Because I didn't want the push to Digital Ocean to happen unless
  the tests and linting pass, I refactored Travis to use staged jobs.
  To make this work, I couldn't use the matrix anymore (which we didn't
  really need anyways) and I needed to move all the env variables to be
  global variables so that they will all be used for every run (in this
  case, we only have one run anyways).

- Updated production deployment instructions to use the container that
  was deployed by Travis