### PR TITLE
Only build and push Docker container if it isn't already in the registry (CU-mrxren)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 doctl registry login
-docker build -t registry.digitalocean.com/odetect/odetect-prod:$(git log -1 --format=%h) .
-docker push registry.digitalocean.com/odetect/odetect-prod:$(git log -1 --format=%h)
+
+# Check if the repository already has a container with this tag
+if ! [[ $(doctl registry repository list-tags --format Tag --no-header odetect-prod | grep $(git log -1 --format=%h)) ]]; then
+    docker build -t registry.digitalocean.com/odetect/odetect-prod:$(git log -1 --format=%h) .
+    docker push registry.digitalocean.com/odetect/odetect-prod:$(git log -1 --format=%h)
+fi


### PR DESCRIPTION
- Since our tags are based on the git commit number, if the tag already
  exists in the registry, then the exact code has already been pushed
  and doesn't need to be done again.
- This will save us time (by not building and pushing when we don't have
  to) and it will decrease the number of times that we pull from Docker
  Hub (which as a rate limit of 100 pulls every 6 hours).

What do you think of this? It means that there will be far fewer Docker pushes by Travis, but will it interfere with local dev? It means that you'll need to be sure to update your git commit before pushing each time you want to send up a new version or else it won't do what you think it will. I think that's probably OK since using the same tag more than once with different code _also_ doesn't necessarily do what one would think it should do (hence why we moved from `latest` to the short git hash as the tag).