### PR TITLE
Do transaction-handling and use Location/Session objects consistently across all DB functions (CU-kry5t5)

### DIFF
--- a/BraveAlerterConfigurator.js
+++ b/BraveAlerterConfigurator.js
@@ -28,10 +28,10 @@ class BraveAlerterConfigurator {
 
     const alertSession = new AlertSession(
       session.sessionid,
-      session.chatbot_state,
-      session.incidenttype,
+      session.chatbotState,
+      session.incidentType,
       undefined,
-      `An alert to check on the washroom at ${locationData.display_name} was not responded to. Please check on it`,
+      `An alert to check on the washroom at ${locationData.displayName} was not responded to. Please check on it`,
       locationData.phonenumber,
       incidentTypeKeys,
       incidentTypes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- More consistent DB interactions (CU-kry5t5)
+
 ### Added
 
 - Ability to have multiple fallback phone numbers (CU-pv8hd5)

--- a/InnosentStateMachine.js
+++ b/InnosentStateMachine.js
@@ -16,8 +16,8 @@ class InnosentStateMachine {
     const innosentHistory = await redis.getInnosentWindow(this.location, '+', '-', 25)
     const door = await redis.getLatestDoorSensorData(this.location)
     const states = await redis.getLatestLocationStatesData(this.location)
-    const DOOR_THRESHOLD_MILLIS = locationData.door_stickiness_delay
-    const mov_threshold = locationData.mov_threshold
+    const DOOR_THRESHOLD_MILLIS = locationData.doorStickinessDelay
+    const mov_threshold = locationData.movThreshold
     const currentTime = moment()
     const latestDoor = moment(door.timestamp, 'x')
     const doorDelay = currentTime.diff(latestDoor)
@@ -74,23 +74,23 @@ class InnosentStateMachine {
           state = STATE.RESET
           break
         case STATE.MOVEMENT:
-          if (door.signal === DOOR_STATE.OPEN && session.od_flag === OD_FLAG_STATE.NO_OVERDOSE) {
+          if (door.signal === DOOR_STATE.OPEN && session.odFlag === OD_FLAG_STATE.NO_OVERDOSE) {
             state = STATE.DOOR_OPENED_CLOSE
           } else if (inPhase_avg < mov_threshold) {
             state = STATE.STILL
           }
-          if (session.od_flag === OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspectedInnosent(session, locationData))) {
+          if (session.odFlag === OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspectedInnosent(session, locationData))) {
             state = STATE.SUSPECTED_OD
           }
 
           break
         case STATE.STILL:
-          if (door.signal === DOOR_STATE.OPEN && session.od_flag === OD_FLAG_STATE.NO_OVERDOSE) {
+          if (door.signal === DOOR_STATE.OPEN && session.odFlag === OD_FLAG_STATE.NO_OVERDOSE) {
             state = STATE.DOOR_OPENED_CLOSE
           } else if (inPhase_avg > mov_threshold) {
             state = STATE.MOVEMENT
           }
-          if (session.od_flag === OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspectedInnosent(session, locationData))) {
+          if (session.odFlag === OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspectedInnosent(session, locationData))) {
             state = STATE.SUSPECTED_OD
           }
 

--- a/XeThruStateMachine.js
+++ b/XeThruStateMachine.js
@@ -18,8 +18,8 @@ class XeThruStateMachine {
     const xethru = xethru_history[0]
     const door = await redis.getLatestDoorSensorData(this.location)
     const states = await redis.getLatestLocationStatesData(this.location)
-    const DOOR_THRESHOLD_MILLIS = locationData.door_stickiness_delay
-    const residual_mov_f = locationData.mov_threshold
+    const DOOR_THRESHOLD_MILLIS = locationData.doorStickinessDelay
+    const residual_mov_f = locationData.movThreshold
     const currentTime = moment()
     const latestDoor = moment(door.timestamp, 'x')
     const doorDelay = currentTime.diff(latestDoor)
@@ -102,7 +102,7 @@ class XeThruStateMachine {
           break
         case STATE.MOVEMENT:
           // eslint-disable-next-line eqeqeq
-          if (door.signal == DOOR_STATE.OPEN && session.od_flag == OD_FLAG_STATE.NO_OVERDOSE) {
+          if (door.signal == DOOR_STATE.OPEN && session.odFlag == OD_FLAG_STATE.NO_OVERDOSE) {
             state = STATE.DOOR_OPENED_CLOSE
           }
           // if in breathing state, change to that state
@@ -115,14 +115,14 @@ class XeThruStateMachine {
           }
 
           // eslint-disable-next-line eqeqeq
-          if (session.od_flag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
+          if (session.odFlag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
             state = STATE.SUSPECTED_OD
           }
 
           break
         case STATE.STILL:
           // eslint-disable-next-line eqeqeq
-          if (door.signal == DOOR_STATE.OPEN && session.od_flag == OD_FLAG_STATE.NO_OVERDOSE) {
+          if (door.signal == DOOR_STATE.OPEN && session.odFlag == OD_FLAG_STATE.NO_OVERDOSE) {
             state = STATE.DOOR_OPENED_CLOSE
             // eslint-disable-next-line eqeqeq
           } else if (xethru.state == XETHRU_STATE.BREATHING) {
@@ -132,14 +132,14 @@ class XeThruStateMachine {
           }
 
           // eslint-disable-next-line eqeqeq
-          if (session.od_flag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
+          if (session.odFlag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
             state = STATE.SUSPECTED_OD
           }
 
           break
         case STATE.BREATH_TRACKING:
           // eslint-disable-next-line eqeqeq
-          if (door.signal == DOOR_STATE.OPEN && session.od_flag == OD_FLAG_STATE.NO_OVERDOSE) {
+          if (door.signal == DOOR_STATE.OPEN && session.odFlag == OD_FLAG_STATE.NO_OVERDOSE) {
             state = STATE.DOOR_OPENED_CLOSE
             // eslint-disable-next-line eqeqeq
           } else if (xethru.state != XETHRU_STATE.BREATHING && xethru.mov_f == 0) {
@@ -153,7 +153,7 @@ class XeThruStateMachine {
 
           // If the flag was originally false and the overdose criteria are met, an overdose is ssuspected and the flag is enabled.
           // eslint-disable-next-line eqeqeq
-          if (session.od_flag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
+          if (session.odFlag == OD_FLAG_STATE.NO_OVERDOSE && (await db.isOverdoseSuspected(xethru, session, locationData))) {
             state = STATE.SUSPECTED_OD
           }
 

--- a/db/db.js
+++ b/db/db.js
@@ -25,46 +25,15 @@ pool.on('error', err => {
   helpers.logError(`unexpected database error: ${JSON.stringify(err)}`)
 })
 
-async function getCurrentTime(clientParam) {
-  let client = clientParam
-  const transactionMode = typeof client !== 'undefined'
-
-  try {
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    const { rows } = await client.query('SELECT NOW()')
-    const time = rows[0].now
-
-    return time
-  } catch (e) {
-    helpers.log(`Error running the getCurrentTime query: ${e}`)
-  } finally {
-    if (!transactionMode) {
-      try {
-        client.release()
-      } catch (err) {
-        helpers.log(`getCurrentTime: Error releasing client: ${err}`)
-      }
-    }
-  }
-}
-
-// Functions added to facilitate moving to Mustache template from angular front end
-// prettier-ignore
 function createSessionFromRow(r) {
+  // prettier-ignore
   return new Session(r.locationid, r.start_time, r.end_time, r.od_flag, r.state, r.phonenumber, r.notes, r.incidenttype, r.sessionid, r.duration, r.still_counter, r.chatbot_state, r.alert_reason)
 }
 
-// prettier-ignore
 function createLocationFromRow(r) {
+  // prettier-ignore
   return new Location(r.locationid, r.display_name, r.phonenumber, r.sensitivity, r.led, r.noisemap, r.mov_threshold, r.duration_threshold, r.still_threshold, r.rpm_threshold, r.heartbeat_sent_alerts, r.heartbeat_alert_recipient, r.door_particlecoreid, r.radar_particlecoreid, r.radar_type, r.reminder_timer, r.fallback_timer, r.auto_reset_threshold, r.twilio_number, r.fallback_phonenumbers, r.door_stickiness_delay)
 }
-
-// The following functions will route HTTP requests into database queries
-
-// GET all XeThru data
 
 async function beginTransaction() {
   const client = await pool.connect()
@@ -78,245 +47,278 @@ async function commitTransaction(client) {
   client.release()
 }
 
-// Gets the most recent session data in the table for a specified location
-async function getMostRecentSession(locationid, clientParam) {
+async function rollbackTransaction(client) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
+    await client.query('ROLLBACK')
+  } catch (e) {
+    helpers.log(`Error running the rollbackTransaction query: ${e}`)
+  } finally {
+    try {
+      client.release()
+    } catch (err) {
+      helpers.log(`rollbackTransaction: Error releasing client: ${err}`)
+    }
+  }
+}
+
+async function runQuery(functionName, queryString, queryParams, clientParam) {
+  let client = clientParam
+  const transactionMode = typeof client !== 'undefined'
+
+  try {
     if (!transactionMode) {
       client = await pool.connect()
     }
-    const results = await client.query('SELECT * FROM sessions WHERE locationid = $1 ORDER BY sessionid DESC LIMIT 1', [locationid])
+
+    return await client.query(queryString, queryParams)
+  } catch (e) {
+    helpers.log(`Error running the ${functionName} query: ${e}`)
+  } finally {
     if (!transactionMode) {
-      client.release()
+      try {
+        client.release()
+      } catch (err) {
+        helpers.log(`${functionName}: Error releasing client: ${err}`)
+      }
     }
+  }
+}
+
+async function getCurrentTime(clientParam) {
+  try {
+    const results = await runQuery('getCurrentTime', 'SELECT NOW()', [], clientParam)
+
+    return results.rows[0].now
+  } catch (err) {
+    // Errors handled in runQuery
+  }
+}
+
+// Gets the most recent session data in the table for a specified location
+async function getMostRecentSession(locationid, clientParam) {
+  try {
+    const results = await runQuery(
+      'getMostRecentSession',
+      'SELECT * FROM sessions WHERE locationid = $1 ORDER BY sessionid DESC LIMIT 1',
+      [locationid],
+      clientParam,
+    )
+
     if (typeof results === 'undefined') {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the getMostRecentSession query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Gets session with a specific SessionID
 async function getSessionWithSessionId(sessionid, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    const results = await client.query('SELECT * FROM sessions WHERE sessionid = $1', [sessionid])
-
-    if (!transactionMode) {
-      client.release()
-    }
-
-    if (typeof results === 'undefined') {
-      return null
-    }
+    const results = await runQuery('getSessionWithSessionId', 'SELECT * FROM sessions WHERE sessionid = $1', [sessionid], clientParam)
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the getSessionWithSessionId query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Gets the last session data in the table for a specified phone number
 async function getMostRecentSessionPhone(twilioNumber, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-    const results = await client.query(
+    const results = await runQuery(
+      'getMostRecentSessionPhone',
       "SELECT s.* FROM sessions AS s LEFT JOIN locations AS l ON s.locationid = l.locationid WHERE l.twilio_number = $1  AND s.start_time > (CURRENT_TIMESTAMP - interval '7 days') ORDER BY s.start_time DESC LIMIT 1",
       [twilioNumber],
+      clientParam,
     )
-    if (!transactionMode) {
-      client.release()
-    }
+
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the getMostRecentSessionPhone query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
-async function getHistoryOfSessions(locationid) {
+async function getHistoryOfSessions(locationid, clientParam) {
   try {
-    const results = await pool.query('SELECT * FROM sessions WHERE locationid = $1 ORDER BY sessionid DESC LIMIT 200', [locationid])
+    const results = await runQuery(
+      'getHistoryOfSessions',
+      'SELECT * FROM sessions WHERE locationid = $1 ORDER BY sessionid DESC LIMIT 200',
+      [locationid],
+      clientParam,
+    )
 
     if (typeof results === 'undefined') {
       return null
     }
 
     return results.rows.map(r => createSessionFromRow(r))
-  } catch (e) {
-    helpers.log(`Error running the getHistoryOfSessions query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
-async function getAllSessionsFromLocation(location) {
+async function getAllSessionsFromLocation(location, clientParam) {
   try {
-    const results = await pool.query('SELECT * FROM sessions WHERE locationid = $1 order by start_time desc', [location])
+    const results = await runQuery(
+      'getAllSessionsFromLocation',
+      'SELECT * FROM sessions WHERE locationid = $1 order by start_time desc',
+      [location],
+      clientParam,
+    )
 
     if (!results) {
       return null
     }
 
     return results.rows
-  } catch (e) {
-    helpers.log(`Error running the getAllSessionsFromLocation query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Gets the last session data from an unclosed session for a specified location
-async function getLastUnclosedSession(locationid) {
+async function getLastUnclosedSession(locationid, clientParam) {
   try {
-    const results = await pool.query(
+    const results = runQuery(
+      'getLastUnclosedSession',
       "SELECT * FROM sessions WHERE locationid = $1  AND start_time > (CURRENT_TIMESTAMP - interval '7 days') AND end_time = null ORDER BY sessionid DESC LIMIT 1",
       [locationid],
+      clientParam,
     )
+
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the getLastUnclosedSession query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Creates a new session for a specific location
 async function createSession(phone, locationid, state, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-    const results = await client.query('INSERT INTO sessions(phonenumber, locationid, state, od_flag) VALUES ($1, $2, $3, $4) RETURNING *', [
-      phone,
-      locationid,
-      state,
-      OD_FLAG_STATE.NO_OVERDOSE,
-    ])
-    if (!transactionMode) {
-      client.release()
-    }
+    const results = await runQuery(
+      'createSession',
+      'INSERT INTO sessions(phonenumber, locationid, state, od_flag) VALUES ($1, $2, $3, $4) RETURNING *',
+      [phone, locationid, state, OD_FLAG_STATE.NO_OVERDOSE],
+      clientParam,
+    )
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the createSession query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Enters the end time of a session when it closes and calculates the duration of the session
 async function updateSessionEndTime(sessionid, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
+    await runQuery('updateSessionEndTime', 'UPDATE sessions SET end_time = CURRENT_TIMESTAMP WHERE sessionid = $1', [sessionid], clientParam)
 
-    await client.query('UPDATE sessions SET end_time = CURRENT_TIMESTAMP WHERE sessionid = $1', [sessionid])
-    client.query("UPDATE sessions SET duration = TO_CHAR(age(end_time, start_time),'HH24:MI:SS') WHERE sessionid = $1", [sessionid]) // Sets the duration to the difference between the end and start time
-    if (!transactionMode) {
-      client.release()
-    }
-  } catch (e) {
-    helpers.log(`Error running the updateSessionEndTime query: ${e}`)
+    // Sets the duration to the difference between the end and start time
+    await runQuery(
+      'updateSessionEndTime',
+      "UPDATE sessions SET duration = TO_CHAR(age(end_time, start_time),'HH24:MI:SS') WHERE sessionid = $1",
+      [sessionid],
+      clientParam,
+    )
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Closes the session by updating the end time
-async function closeSession(sessionid, client) {
-  await updateSessionEndTime(sessionid, client)
+async function closeSession(sessionid, clientParam) {
+  try {
+    await updateSessionEndTime(sessionid, clientParam)
+  } catch (err) {
+    // Errors handled in runQuery
+  }
 }
 
 // Updates the state value in the sessions database row
 async function updateSessionState(sessionid, state, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-    const results = await client.query('UPDATE sessions SET state = $1 WHERE sessionid = $2 RETURNING *', [state, sessionid])
-    if (!transactionMode) {
-      client.release()
-    }
+    const results = await runQuery(
+      'updateSessionState',
+      'UPDATE sessions SET state = $1 WHERE sessionid = $2 RETURNING *',
+      [state, sessionid],
+      clientParam,
+    )
+
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the updateSessionState query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Updates the value of the alert flag in the location database
-async function updateSentAlerts(location, sentalerts) {
+async function updateSentAlerts(location, sentalerts, clientParam) {
   try {
-    const results = await pool.query('UPDATE locations SET heartbeat_sent_alerts = $1 WHERE locationid = $2 RETURNING *', [sentalerts, location])
+    const results = await runQuery(
+      'updateSentAlerts',
+      'UPDATE locations SET heartbeat_sent_alerts = $1 WHERE locationid = $2 RETURNING *',
+      [sentalerts, location],
+      clientParam,
+    )
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the updateSentAlerts query ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 async function updateSessionResetDetails(sessionid, notes, state, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    const results = await client.query('UPDATE sessions SET state = $1, notes = $2 WHERE sessionid = $3 RETURNING *', [state, notes, sessionid])
-    if (!transactionMode) {
-      client.release()
-    }
+    const results = await runQuery(
+      'updateSessionResetDetails',
+      'UPDATE sessions SET state = $1, notes = $2 WHERE sessionid = $3 RETURNING *',
+      [state, notes, sessionid],
+      clientParam,
+    )
 
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the updateSessionResetDetails query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Updates the still_counter in the sessions database row
 
-async function updateSessionStillCounter(stillcounter, sessionid, locationid) {
+async function updateSessionStillCounter(stillcounter, sessionid, locationid, clientParam) {
   try {
-    const results = await pool.query('UPDATE sessions SET still_counter = $1 WHERE sessionid = $2 AND locationid = $3 RETURNING *', [
-      stillcounter,
-      sessionid,
-      locationid,
-    ])
+    const results = await runQuery(
+      'updateSessionStillCounter',
+      'UPDATE sessions SET still_counter = $1 WHERE sessionid = $2 AND locationid = $3 RETURNING *',
+      [stillcounter, sessionid, locationid],
+      clientParam,
+    )
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the updateSessionStillCounter query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
@@ -353,23 +355,16 @@ async function isOverdoseSuspectedInnosent(session, location, clientParam) {
     if (condition2 + condition3 >= conditionThreshold) {
       // update the table entry so od_flag is 1
       try {
-        let client = clientParam
-        const transactionMode = typeof client !== 'undefined'
-        if (!transactionMode) {
-          client = await pool.connect()
-        }
-        await client.query('UPDATE sessions SET od_flag = $1, alert_reason = $2  WHERE sessionid = $3', [
-          OD_FLAG_STATE.OVERDOSE,
-          alertReason,
-          session.sessionid,
-        ])
-        if (!transactionMode) {
-          client.release()
-        }
+        await runQuery(
+          'isOverdoseSuspectedInnosent',
+          'UPDATE sessions SET od_flag = $1, alert_reason = $2  WHERE sessionid = $3',
+          [OD_FLAG_STATE.OVERDOSE, alertReason, session.sessionid],
+          clientParam,
+        )
 
         return true
       } catch (err) {
-        helpers.log(`Error running od_flag update query ${err}`)
+        // Errors handled in runQuery
       }
     }
 
@@ -425,23 +420,16 @@ async function isOverdoseSuspected(xethru, session, location, clientParam) {
     if (condition1 + condition2 + condition3 >= conditionThreshold) {
       // update the table entry so od_flag is 1
       try {
-        let client = clientParam
-        const transactionMode = typeof client !== 'undefined'
-        if (!transactionMode) {
-          client = await pool.connect()
-        }
+        await runQuery(
+          'isOverdoseSuspected',
+          'UPDATE sessions SET od_flag = $1, alert_reason = $2  WHERE sessionid = $3',
+          [OD_FLAG_STATE.OVERDOSE, alertReason, session.sessionid],
+          clientParam,
+        )
 
-        await client.query('UPDATE sessions SET od_flag = $1, alert_reason = $2  WHERE sessionid = $3', [
-          OD_FLAG_STATE.OVERDOSE,
-          alertReason,
-          session.sessionid,
-        ])
-        if (!transactionMode) {
-          client.release()
-        }
         return true
       } catch (err) {
-        helpers.log(`Error running od_flag update query: ${err}`)
+        // Errors handled in runQuery
       }
     }
     return false
@@ -453,86 +441,73 @@ async function isOverdoseSuspected(xethru, session, location, clientParam) {
 // Saves the state and incident type into the sessions table
 async function saveAlertSession(chatbotState, incidentType, sessionid, clientParam) {
   try {
-    let client = clientParam
-    const transactionMode = typeof client !== 'undefined'
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    await client.query('UPDATE sessions SET chatbot_state = $1, incidenttype = $2 WHERE sessionid = $3', [chatbotState, incidentType, sessionid])
-
-    if (!transactionMode) {
-      client.release()
-    }
-  } catch (e) {
-    helpers.log(`Error running the saveAlertSession query: ${e}`)
+    await runQuery(
+      'saveAlertSession',
+      'UPDATE sessions SET chatbot_state = $1, incidenttype = $2 WHERE sessionid = $3',
+      [chatbotState, incidentType, sessionid],
+      clientParam,
+    )
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Retrieves the data from the locations table for a given location
-async function getLocationData(locationid) {
+async function getLocationData(locationid, clientParam) {
   try {
-    const results = await pool.query('SELECT * FROM locations WHERE locationid = $1', [locationid])
+    const results = await runQuery('getLocationData', 'SELECT * FROM locations WHERE locationid = $1', [locationid], clientParam)
+
     if (results === undefined) {
       return null
     }
 
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the getLocationData query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Retrieves the locationid corresponding to a particle device coreID
 async function getLocationFromParticleCoreID(coreID, clientParam) {
-  let client = clientParam
-  const transactionMode = typeof client !== 'undefined'
-
   try {
-    if (!transactionMode) {
-      client = await pool.connect()
-    }
-
-    const results = await client.query('SELECT * FROM locations WHERE door_particlecoreid = $1 OR radar_particlecoreid = $1', [coreID])
+    const results = await runQuery(
+      'getLocationFromParticleCoreID',
+      'SELECT * FROM locations WHERE door_particlecoreid = $1 OR radar_particlecoreid = $1',
+      [coreID],
+      clientParam,
+    )
     if (results === undefined) {
       helpers.log('Error: No location with associated coreID exists')
       return null
     }
 
     return createLocationFromRow(results.rows[0])
-  } catch (e) {
-    helpers.log(`Error running the getLocationFromParticleCoreID query: ${e}`)
-  } finally {
-    if (!transactionMode) {
-      try {
-        client.release()
-      } catch (err) {
-        helpers.log(`getLocationFromParticleCoreID: Error releasing client: ${err}`)
-      }
-    }
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Retrieves the locations table
-async function getLocations() {
+async function getLocations(clientParam) {
   try {
-    const results = await pool.query('SELECT * FROM locations ORDER BY display_name')
+    const results = await runQuery('getLocations', 'SELECT * FROM locations ORDER BY display_name', [], clientParam)
 
     if (typeof results === 'undefined') {
       return null
     }
 
     return results.rows.map(r => createLocationFromRow(r))
-  } catch (e) {
-    helpers.log(`Error running the getLocations query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Updates the locations table entry for a specific location with the new data
 // eslint-disable-next-line prettier/prettier
-async function updateLocation(displayName, doorCoreId, radarCoreId, radarType, phonenumber, fallbackNumbers, heartbeatAlertRecipient, twilioNumber, sensitivity, led, noisemap, movThreshold, rpmThreshold, durationThreshold, stillThreshold, autoResetThreshold, doorStickinessDelay, reminderTimer, fallbackTimer, locationid) {
+async function updateLocation(displayName, doorCoreId, radarCoreId, radarType, phonenumber, fallbackNumbers, heartbeatAlertRecipient, twilioNumber, sensitivity, led, noisemap, movThreshold, rpmThreshold, durationThreshold, stillThreshold, autoResetThreshold, doorStickinessDelay, reminderTimer, fallbackTimer, locationid, clientParam,) {
   try {
-    const results = await pool.query(
+    const results = await runQuery(
+      'updateLocation',
       'UPDATE locations SET display_name = $1, door_particlecoreid = $2, radar_particlecoreid = $3, radar_type = $4, phonenumber = $5, fallback_phonenumbers = $6, heartbeat_alert_recipient = $7, twilio_number = $8, sensitivity = $9, led = $10, noisemap = $11, mov_threshold = $12, rpm_threshold = $13, duration_threshold = $14, still_threshold = $15, auto_reset_threshold = $16, door_stickiness_delay = $17, reminder_timer = $18, fallback_timer = $19 WHERE locationid = $20 returning *',
       [
         displayName,
@@ -556,20 +531,21 @@ async function updateLocation(displayName, doorCoreId, radarCoreId, radarType, p
         fallbackTimer,
         locationid,
       ],
+      clientParam,
     )
 
     helpers.log(`Location '${locationid}' successfully updated`)
     return results.rows[0]
-  } catch (e) {
-    helpers.log(`Error running the updateLocation query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
 // Adds a location table entry from browser form, named this way with an extra word because "FromForm" is hard to read
 // prettier-ignore
-async function createLocationFromBrowserForm(locationid, displayName, doorCoreId, radarCoreId, radarType, phonenumber, twilioNumber) {
+async function createLocationFromBrowserForm(locationid, displayName, doorCoreId, radarCoreId, radarType, phonenumber, twilioNumber, clientParam) {
   try {
-    await pool.query(
+    await runQuery('createLocationFromBrowserForm',
       'INSERT INTO locations(locationid, display_name, door_particlecoreid, radar_particlecoreid, radar_type, phonenumber, twilio_number) VALUES ($1, $2, $3, $4, $5, $6, $7)',
       [
         locationid,
@@ -580,19 +556,20 @@ async function createLocationFromBrowserForm(locationid, displayName, doorCoreId
         phonenumber,
         twilioNumber,
       ],
+      clientParam,
     )
 
     helpers.log(`New location inserted into Database: ${locationid}`)
-  } catch (e) {
-    helpers.log(`Error running the createLocationFromBrowserForm query: ${e}`)
-  }
+  } catch (err) {// Errors handled in runQuery
+}
 }
 
 // Adds a location table entry
 // eslint-disable-next-line prettier/prettier
-async function createLocation(locationid, phonenumber, movThreshold, stillThreshold, durationThreshold, reminderTimer, autoResetThreshold, doorStickinessDelay, heartbeatAlertRecipient, twilioNumber, fallbackNumbers, fallbackTimer, displayName, doorCoreId, radarCoreId, radarType, sensitivity, led, noisemap, rpmThreshold) {
+async function createLocation(locationid, phonenumber, movThreshold, stillThreshold, durationThreshold, reminderTimer, autoResetThreshold, doorStickinessDelay, heartbeatAlertRecipient, twilioNumber, fallbackNumbers, fallbackTimer, displayName, doorCoreId, radarCoreId, radarType, sensitivity, led, noisemap, rpmThreshold, clientParam,) {
   try {
-    await pool.query(
+    await runQuery(
+      'createLocation',
       'INSERT INTO locations(locationid, phonenumber, mov_threshold, still_threshold, duration_threshold, reminder_timer, auto_reset_threshold, door_stickiness_delay, heartbeat_alert_recipient, twilio_number, fallback_phonenumbers, fallback_timer, display_name, door_particlecoreid, radar_particlecoreid, radar_type, sensitivity, led, noisemap, rpm_threshold) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)',
       [
         locationid,
@@ -616,46 +593,53 @@ async function createLocation(locationid, phonenumber, movThreshold, stillThresh
         noisemap,
         rpmThreshold,
       ],
+      clientParam,
     )
     helpers.log('New location inserted into Database')
-  } catch (e) {
-    helpers.log(`Error running the createLocation query: ${e}`)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
-async function clearSessions() {
+async function clearSessions(clientParam) {
   if (!helpers.isTestEnvironment()) {
     helpers.log('warning - tried to clear sessions database outside of a test environment!')
     return
   }
+
   try {
-    await pool.query('DELETE FROM sessions')
-  } catch (e) {
-    helpers.log(`Error running clearSessions: ${e}`)
+    await runQuery('clearSessions', 'DELETE FROM sessions', [], clientParam)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
-async function clearSessionsFromLocation(locationid) {
+async function clearSessionsFromLocation(locationid, clientParam) {
   try {
-    await pool.query('DELETE FROM sessions where locationid = $1', [locationid])
-  } catch (e) {
-    helpers.log(`Error running clearSessionsFromLocation: ${e}`)
+    await runQuery('clearSessionsFromLocation', 'DELETE FROM sessions where locationid = $1', [locationid], clientParam)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
-async function clearLocations() {
+async function clearLocations(clientParam) {
   if (!helpers.isTestEnvironment()) {
     helpers.log('warning - tried to clear locations table outside of a test environment!')
     return
   }
-  await pool.query('DELETE FROM locations')
+
+  try {
+    await runQuery('clearLocations', 'DELETE FROM locations', [], clientParam)
+  } catch (err) {
+    // Errors handled in runQuery
+  }
 }
 
-async function clearLocation(locationid) {
+async function clearLocation(locationid, clientParam) {
   try {
-    await pool.query('DELETE FROM locations where locationid = $1', [locationid])
-  } catch (e) {
-    helpers.log(`Error running clearLocation: ${e}`)
+    await runQuery('clearLocation', 'DELETE FROM locations where locationid = $1', [locationid], clientParam)
+  } catch (err) {
+    // Errors handled in runQuery
   }
 }
 
@@ -691,6 +675,7 @@ module.exports = {
   getAllSessionsFromLocation,
   beginTransaction,
   commitTransaction,
+  rollbackTransaction,
   getCurrentTime,
   createLocationFromBrowserForm,
 }

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ if (!helpers.isTestEnvironment()) {
 async function sendSingleAlert(locationid, message) {
   const location = await db.getLocationData(locationid)
 
-  await braveAlerter.sendSingleAlert(location.heartbeat_alert_recipient, location.twilio_number, message)
+  await braveAlerter.sendSingleAlert(location.heartbeatAlertRecipient, location.twilioNumber, message)
 }
 
 async function sendAlerts(locationid) {
@@ -266,7 +266,7 @@ async function handleSensorRequest(currentLocationId, radarType) {
 
   // If session duration is longer than the threshold (20 min), reset the session at this location, send an alert to notify as well.
 
-  if (sessionDuration * 1000 > location.auto_reset_threshold) {
+  if (sessionDuration * 1000 > location.autoResetThreshold) {
     autoResetSession(location.locationid)
     start_times[currentLocationId] = null
     helpers.log('autoResetSession has been called')
@@ -288,7 +288,7 @@ async function handleSensorRequest(currentLocationId, radarType) {
 
         if (typeof latestSession !== 'undefined') {
           // Checks if no session exists for this location yet.
-          if (latestSession.end_time == null) {
+          if (latestSession.endTime == null) {
             // Checks if session is open.
             await db.updateSessionState(latestSession.sessionid, currentState, client)
           }
@@ -311,17 +311,17 @@ async function handleSensorRequest(currentLocationId, radarType) {
 
         if (typeof latestSession !== 'undefined') {
           // Checks if session exists
-          if (latestSession.end_time == null) {
+          if (latestSession.endTime == null) {
             // Checks if session is open for this location
             const currentSession = await db.updateSessionState(latestSession.sessionid, currentState, client)
-            start_times[currentLocationId] = currentSession.start_time
+            start_times[currentLocationId] = currentSession.startTime
           } else {
             const currentSession = await db.createSession(location.phonenumber, currentLocationId, currentState, client)
-            start_times[currentLocationId] = currentSession.start_time
+            start_times[currentLocationId] = currentSession.startTime
           }
         } else {
           const currentSession = await db.createSession(location.phonenumber, currentLocationId, currentState, client)
-          start_times[currentLocationId] = currentSession.start_time
+          start_times[currentLocationId] = currentSession.startTime
         }
         await db.commitTransaction(client)
       } catch (e) {
@@ -358,19 +358,19 @@ async function handleSensorRequest(currentLocationId, radarType) {
       const latestSession = await db.getMostRecentSession(currentLocationId)
 
       // eslint-disable-next-line eqeqeq
-      if (latestSession.od_flag == 1) {
-        if (latestSession.chatbot_state === null) {
+      if (latestSession.odFlag == 1) {
+        if (latestSession.chatbotState === null) {
           const alertInfo = {
             sessionId: latestSession.sessionid,
             toPhoneNumber: location.phonenumber,
-            fromPhoneNumber: location.twilio_number,
-            message: `This is a ${latestSession.alert_reason} alert. Please check on the bathroom at ${location.display_name}. Please respond with 'ok' once you have checked on it.`,
-            reminderTimeoutMillis: location.reminder_timer,
-            fallbackTimeoutMillis: location.fallback_timer,
+            fromPhoneNumber: location.twilioNumber,
+            message: `This is a ${latestSession.alertReason} alert. Please check on the bathroom at ${location.displayName}. Please respond with 'ok' once you have checked on it.`,
+            reminderTimeoutMillis: location.reminderTimer,
+            fallbackTimeoutMillis: location.fallbackTimer,
             reminderMessage: `This is a reminder to check on the bathroom`,
-            fallbackMessage: `An alert to check on the bathroom at ${location.display_name} was not responded to. Please check on it`,
-            fallbackToPhoneNumbers: location.fallback_phonenumbers,
-            fallbackFromPhoneNumber: location.twilio_number,
+            fallbackMessage: `An alert to check on the bathroom at ${location.displayName} was not responded to. Please check on it`,
+            fallbackToPhoneNumber: location.fallbackNumbers,
+            fallbackFromPhoneNumber: location.twilioNumber,
           }
           braveAlerter.startAlertSession(alertInfo)
         }
@@ -385,9 +385,9 @@ async function handleSensorRequest(currentLocationId, radarType) {
     // Checks if session is in the STILL state and, if so, how long it has been in that state for.
     if (typeof currentSession !== 'undefined') {
       if (currentSession.state === 'Still' || currentSession.state === 'Breathing') {
-        if (currentSession.end_time == null) {
+        if (currentSession.endTime == null) {
           // Only increases counter if session is open
-          await db.updateSessionStillCounter(currentSession.still_counter + 1, currentSession.sessionid, currentSession.locationid)
+          await db.updateSessionStillCounter(currentSession.stillCounter + 1, currentSession.sessionid, currentSession.locationid)
         } else {
           // If session is closed still emit its data as it is
         }
@@ -454,7 +454,7 @@ app.get('/dashboard', sessionChecker, async (req, res) => {
     for (const location of allLocations) {
       const recentSession = await db.getMostRecentSession(location.locationid)
       if (recentSession) {
-        const sessionStartTime = Date.parse(recentSession.start_time)
+        const sessionStartTime = Date.parse(recentSession.startTime)
         const timeSinceLastSession = await generateCalculatedTimeDifferenceString(sessionStartTime)
         location.sessionStart = timeSinceLastSession
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "test": "NODE_ENV=test mocha --timeout 10000 \"test/**/*.js\"",
     "integrationtest": "NODE_ENV=test mocha --timeout 10000 \"test/serverTest.js\"",
-    "unittest": "NODE_ENV=test mocha --timeout 10000 \"test/testStateMachine.js\"",
+    "unittest": "NODE_ENV=test mocha --timeout 10000 \"test/testXeThruStateMachine.js\"",
     "smoketest": "node -e 'require(\"./smokeTest.js\")'"
   },
   "eslintIgnore": [

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -191,7 +191,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.end_time).to.be.null
+      expect(session.endTime).to.be.null
     })
 
     it('radar data showing movement should be saved to redis, trigger a session, a door opening should end the session', async () => {
@@ -210,7 +210,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(45)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const session = sessions[0]
-      expect(session.end_time).to.not.be.null
+      expect(session.endTime).to.not.be.null
     })
 
     it('radar data showing movement should trigger a session, and cessation of movement without a door event should trigger an alert', async () => {
@@ -224,7 +224,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(100)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].od_flag).to.equal(1)
+      expect(sessions[0].odFlag).to.equal(1)
       await helpers.sleep(1000)
     })
 
@@ -236,7 +236,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(200)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].od_flag).to.equal(1)
+      expect(sessions[0].odFlag).to.equal(1)
     })
   })
 
@@ -313,7 +313,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.end_time).to.be.null
+      expect(session.endTime).to.be.null
     })
 
     it('radar data showing movement should be saved to redis, trigger a session, a door opening should end the session', async () => {
@@ -332,7 +332,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(675)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const session = sessions[0]
-      expect(session.end_time).to.not.be.null
+      expect(session.endTime).to.not.be.null
     })
 
     it('radar data showing movement should trigger a session, and cessation of movement without a door event should trigger an alert', async () => {
@@ -346,7 +346,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(1500)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].od_flag).to.equal(1)
+      expect(sessions[0].odFlag).to.equal(1)
       await helpers.sleep(1000)
     })
 
@@ -358,7 +358,7 @@ describe('Brave Sensor server', () => {
       expect(radarRows.length).to.equal(3000)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
-      expect(sessions[0].od_flag).to.equal(1)
+      expect(sessions[0].odFlag).to.equal(1)
     })
   })
 
@@ -848,26 +848,27 @@ describe('Brave Sensor server', () => {
         it('should update the location in the database', async () => {
           const updatedLocation = await db.getLocationData(this.testLocationIdForEdit)
 
-          expect(updatedLocation.display_name).to.equal(this.goodRequest.displayName)
-          expect(updatedLocation.door_particlecoreid).to.equal(this.goodRequest.doorCoreID)
-          expect(updatedLocation.radar_particlecoreid).to.equal(this.goodRequest.radarCoreID)
-          expect(updatedLocation.radar_type).to.equal(this.goodRequest.radarType)
+          expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
+          expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
+          expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
+          expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
           expect(updatedLocation.phonenumber).to.equal(this.goodRequest.phone)
-          expect(updatedLocation.fallback_phonenumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
-          expect(updatedLocation.heartbeat_alert_recipient).to.equal(this.goodRequest.heartbeatPhone)
-          expect(updatedLocation.twilio_number).to.equal(this.goodRequest.twilioPhone)
+
+          expect(updatedLocation.fallbackNumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
+          expect(updatedLocation.heartbeatAlertRecipient).to.equal(this.goodRequest.heartbeatPhone)
+          expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
 
           chai.assert.equal(updatedLocation.sensitivity, this.goodRequest.sensitivity)
           chai.assert.equal(updatedLocation.led, this.goodRequest.led)
           chai.assert.equal(updatedLocation.noisemap, this.goodRequest.noiseMap)
-          chai.assert.equal(updatedLocation.mov_threshold, this.goodRequest.movThreshold)
-          chai.assert.equal(updatedLocation.rpm_threshold, this.goodRequest.rpmThreshold)
-          chai.assert.equal(updatedLocation.duration_threshold, this.goodRequest.durationThreshold)
-          chai.assert.equal(updatedLocation.still_threshold, this.goodRequest.stillThreshold)
-          chai.assert.equal(updatedLocation.auto_reset_threshold, this.goodRequest.autoResetThreshold)
-          chai.assert.equal(updatedLocation.door_stickiness_delay, this.goodRequest.doorDelay)
-          chai.assert.equal(updatedLocation.reminder_timer, this.goodRequest.reminderTimer)
-          chai.assert.equal(updatedLocation.fallback_timer, this.goodRequest.fallbackTimer)
+          chai.assert.equal(updatedLocation.movThreshold, this.goodRequest.movThreshold)
+          chai.assert.equal(updatedLocation.rpmThreshold, this.goodRequest.rpmThreshold)
+          chai.assert.equal(updatedLocation.durationThreshold, this.goodRequest.durationThreshold)
+          chai.assert.equal(updatedLocation.stillThreshold, this.goodRequest.stillThreshold)
+          chai.assert.equal(updatedLocation.autoResetThreshold, this.goodRequest.autoResetThreshold)
+          chai.assert.equal(updatedLocation.doorStickinessDelay, this.goodRequest.doorDelay)
+          chai.assert.equal(updatedLocation.reminderTimer, this.goodRequest.reminderTimer)
+          chai.assert.equal(updatedLocation.fallbackTimer, this.goodRequest.fallbackTimer)
         })
       })
 

--- a/test/serverTest.js
+++ b/test/serverTest.js
@@ -245,6 +245,7 @@ describe('Brave Sensor server', () => {
       await redis.clearKeys()
       await db.clearSessions()
       await db.clearLocations()
+
       await db.createLocation(
         testLocation1Id,
         testLocation1PhoneNumber,

--- a/test/testBraveAlerterConfigurator.js
+++ b/test/testBraveAlerterConfigurator.js
@@ -11,6 +11,7 @@ const { ALERT_STATE, AlertSession, helpers } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../BraveAlerterConfigurator.js')
 const db = require('../db/db.js')
 const redis = require('../db/redis.js')
+const Session = require('../Session.js')
 
 // Configure Chai
 chai.use(sinonChai)
@@ -45,6 +46,9 @@ describe('BraveAlerterConfigurator', () => {
 
   describe('getAlertSession', () => {
     beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
       this.expectedChatbotState = ALERT_STATE.WAITING_FOR_CATEGORY
       this.expectedIncidentType = 'No One Inside'
       this.expectedLocationDisplayName = 'TEST LOCATION'
@@ -182,10 +186,10 @@ describe('BraveAlerterConfigurator', () => {
       // Don't call real DB or Redis
       sinon.stub(db, 'beginTransaction').returns(this.testClient)
       sinon.stub(db, 'saveAlertSession')
-      sinon.stub(db, 'getSessionWithSessionId').returns({
-        sessionid: this.testSessionId,
-        locationid: this.testLocationId,
-      })
+      const testSession = new Session()
+      testSession.locationid = this.testLocationId
+      testSession.sessionid = this.testSessionId
+      sinon.stub(db, 'getSessionWithSessionId').returns(testSession)
       this.closeSessionStub = sinon.stub(db, 'closeSession')
       sinon.stub(db, 'commitTransaction')
       sinon.stub(redis, 'addStateMachineData')


### PR DESCRIPTION
In the end, I'm pretty happy with this `runQuery` function. I'd tried a few different ways of making this boilerplate in the past but didn't like any of them. This feels pretty straightforward though, so I'm happy. The only annoying part was still needing to put the `await runQuery(...)` call inside a `try/catch` because of the `await` in order to avoid potential `Unhandled Promise Rejection Warning`s. Oh well, it's still less copy-and-pasting than before. What do you think?

In line with the transaction boilerplate, I added `try/catch` blocks around all of our uses of actual transactions in the code, including a call to `rollbackTransaction` in the `catch`.

I also took this opportunity to make sure that we are consistently using the `Location` and `Session` object for all DB functions that return locations or sessions. This meant quite a few changes all over the place, so please let me know if you see anywhere that I've missed!