### PR TITLE
Fix alertSessionChangedCallback to not overwrite session with nulls (CU-tnarab)

### DIFF
--- a/BraveAlerterConfigurator.js
+++ b/BraveAlerterConfigurator.js
@@ -55,13 +55,17 @@ class BraveAlerterConfigurator {
   }
 
   async alertSessionChangedCallback(alertSession) {
-    const incidentType = incidentTypes[incidentTypeKeys.indexOf(alertSession.incidentCategoryKey)]
+    if (alertSession.alertState === undefined && alertSession.incidentCategoryKey === undefined) {
+      return
+    }
+
     let client
 
     try {
       client = await db.beginTransaction()
 
       const session = await db.getSessionWithSessionId(alertSession.sessionId, client)
+      const incidentType = incidentTypes[incidentTypeKeys.indexOf(alertSession.incidentCategoryKey)]
       await db.saveAlertSession(alertSession.alertState, incidentType, alertSession.sessionId, client)
 
       const locationId = session.locationid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the code was deployed.
 
 - Ability to have multiple fallback phone numbers (CU-pv8hd5)
 
+### Fixed
+
+- Sessions are no longer blocked after a fallback message is sent (CU-tnarab)
+
 ## [3.1.0] - 2021-04-12
 
 ### Added

--- a/test/testBraveAlerterConfigurator.js
+++ b/test/testBraveAlerterConfigurator.js
@@ -230,6 +230,32 @@ describe('BraveAlerterConfigurator', () => {
       })
     })
 
+    describe('if given only the fallbackReturnMessage', async () => {
+      beforeEach(async () => {
+        const braveAlerterConfigurator = new BraveAlerterConfigurator(this.testStartTimes)
+        const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+        const alertSession = new AlertSession(this.testSessionId)
+        alertSession.fallbackReturnMessage = 'queued'
+        await braveAlerter.alertSessionChangedCallback(alertSession)
+      })
+
+      it('should not update the sesssion at all', () => {
+        expect(db.saveAlertSession).not.to.be.called
+      })
+
+      it('should not close the session', () => {
+        expect(db.closeSession).not.to.be.called
+      })
+
+      it('should not update the startTimes', () => {
+        expect(this.testStartTimes[this.testLocationId] === this.initialTestStartTime)
+      })
+
+      it('should not reset redis', () => {
+        expect(redis.addStateMachineData).not.to.be.called
+      })
+    })
+
     describe('if given a COMPLETE chatbotState and incidentTypeKey', async () => {
       beforeEach(async () => {
         this.closeSessionStub.returns(true)


### PR DESCRIPTION
- After the fallback message is sent by brave-alert-lib, it calls
  alertSessionChangedCallback with an alertSession object containing
  ONLY the session ID and the results from calling Twilio. The code
  was taking that and blindly setting the chatbot state and
  incidenttype based on that alertSession object, thus setting those
  values to null every time the fallback message is sent. Now it tries
  to be smarter and will re-save the current values if given undefined