### PR TITLE
Add ability to set Locations to inactive (CU-rk8axg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ the code was deployed.
 - Ability to send heartbeats to multiple recipients (CU-rx46w0)
 - Tracking errors and outages with Sentry (CU-px7k6e)
 - API Key for locations (CU-hjwazd)
+- Concept of active/inactive locations (CU-rk8axg)
 
 ### Changed
 - Improved some API error messages.
 - Heartbeat text now contains troubleshooting instructions and contact email for follow-up. (CU-rx46w0)
+- Do not change state or send alerts for inactive locations (CU-rk8axg)
 
 ### Fixed
 - Helm chart RELEASE variable error when the image tag happened to be an integer.

--- a/Location.js
+++ b/Location.js
@@ -1,6 +1,6 @@
 class Location {
   // prettier-ignore
-  constructor(locationid, displayName, phonenumber, sensitivity, led, noisemap, movThreshold, durationThreshold, stillThreshold, rpmThreshold, heartbeatSentAlerts, heartbeatAlertRecipients, doorCoreId, radarCoreId, radarType, reminderTimer, fallbackTimer, autoResetThreshold, twilioNumber, fallbackNumbers, doorStickinessDelay, alertApiKey) {
+  constructor(locationid, displayName, phonenumber, sensitivity, led, noisemap, movThreshold, durationThreshold, stillThreshold, rpmThreshold, heartbeatSentAlerts, heartbeatAlertRecipients, doorCoreId, radarCoreId, radarType, reminderTimer, fallbackTimer, autoResetThreshold, twilioNumber, fallbackNumbers, doorStickinessDelay, alertApiKey, isActive) {
     this.locationid = locationid
     this.displayName = displayName
     this.phonenumber = phonenumber
@@ -23,6 +23,7 @@ class Location {
     this.fallbackNumbers = fallbackNumbers
     this.doorStickinessDelay = doorStickinessDelay
     this.alertApiKey = alertApiKey
+    this.isActive = isActive
   }
 }
 

--- a/db/017-add-is-active-to-locations.sql
+++ b/db/017-add-is-active-to-locations.sql
@@ -1,0 +1,26 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 17;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE locations 
+        ADD COLUMN is_active boolean
+        DEFAULT false;
+
+        UPDATE locations
+        SET is_active = true;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/mustache-templates/landingPage.mst
+++ b/mustache-templates/landingPage.mst
@@ -23,6 +23,7 @@
                 <table class="table table-striped table-sm table-fixed">
                     <thead>
                         <tr class="table-header" scope="row">
+                            <th scope="col"></th>
                             <th scope="col"><h5>Location</h5></th>
                             <th scope="col"><h5>Last Session Started</h5></th>
                         </tr>
@@ -30,6 +31,7 @@
                     <tbody>
                     {{#locations}}
                         <tr class="table-data">
+                            <td>{{^isActive}}[INACTIVE]{{/isActive}}</td>
                             <th scope="row"><a href="/locations/{{id}}">{{name}}</a></th>
                             <td>{{sessionStart}}</td>
                         </tr>

--- a/mustache-templates/newLocation.mst
+++ b/mustache-templates/newLocation.mst
@@ -77,6 +77,7 @@
                     </div>
                 </div>
                 <br>
+                <p><em>*** Remember: New Locations are set to INACTIVE ***</em></p>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>
         </div>

--- a/mustache-templates/updateLocation.mst
+++ b/mustache-templates/updateLocation.mst
@@ -155,6 +155,13 @@
                         <input type="text" class="form-control" name="fallbackTimer" placeholder="Fallback Message Timer (milliseconds)" value="{{fallbackTimer}}" required>
                     </div>
                 </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="isActive" class="col-sm-3 col-form-label">Is this Location active?</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="isActive" value="{{isActive}}" required pattern="(true|false)">
+                        <small id="isActiveHelp" class="form-text text-muted">"true" or "false"</small>
+                    </div>
+                </div>
                 <br>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>

--- a/setup_postgresql.sh
+++ b/setup_postgresql.sh
@@ -15,3 +15,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/014-alterfallbackphonenumbertobeanarray.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/015-add-api-key-to-locations.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/016-alterheatbeackphonenumbertobeanarray.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/017-add-is-active-to-locations.sql

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -9,6 +9,9 @@ const db = require('../../../db/db.js')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumber', () => {
   beforeEach(async () => {
+    await db.clearSessions()
+    await db.clearLocations()
+
     this.expectedChatbotState = ALERT_STATE.WAITING_FOR_CATEGORY
     this.expectedIncidentType = 'No One Inside'
     this.expectedLocationDisplayName = 'TEST LOCATION'
@@ -38,6 +41,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
       1,
       1,
       'alertApiKey',
+      true,
     )
     const locationId = (await db.getLocations())[0].locationid
 

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -40,6 +40,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
       1,
       1,
       'alertApiKey',
+      true,
     )
     const locationId = (await db.getLocations())[0].locationid
 

--- a/test/integration/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
@@ -36,6 +36,7 @@ describe('BraveAlerterConfigurator.js integration tests: getLocationByAlertApiKe
       1,
       1,
       'myApiKey',
+      true,
     )
   })
 
@@ -85,6 +86,7 @@ describe('BraveAlerterConfigurator.js integration tests: getLocationByAlertApiKe
         1,
         1,
         'myApiKey',
+        true,
       )
     })
 


### PR DESCRIPTION
- Inactive locations will not send out duration, stillness, or heartbeat
  alerts or change state, but they will still record sensor and vitals
  data and will still notify Sentry of low batteries in door sensors
- Locations created through the UI will be ~active~ inactive by default. But existing Locations will be active.
- Added a column on the Landing Dashboard to indicate if a Location
  is inactive
- Added a note on the Add A Location page to warn users that newly created Locations will be inactive.

Things I tested:
- Given is_active set to false and no open sessions. When I closed the door and moved around for longer than the duration_timer. Then no session was started, no alerts were sent, and no state changes were logged.
- Given is_active set to false and there is a session and the od_flag is false. When I open and close the door. Then the session stays open, no alerts are sent, and no state changes were logged.
- Given is_active set to false and there is a session and the od_flag is false. When I receive the alert. Then I am able to finish the chatbot session as normal to close the session.
- Given is_active set to false and there is a session and the od_flag is false. When I wait longer than the auto-reset threshold. Then the session is not auto-reset and no auto-reset message is sent.
- Toggling is_active between true and false at various points to see if I could get it into a weird state, but it all seemed to make sense.
- Given is_active set to false. When I disconnect the device. Then no disconnection alert is sent to me and no disconnection log is logged in Sentry.
- Given is_active set to false. When I reconnect the device. Then no reconnection alert is sent to me and no reconnection log is logged in Sentry.

Didn't know how to test:
- Low door battery alert