### PR TITLE
Update Brave Alert Lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- logSentry calls appear as messages instead of exceptions (CU-px7k6e)
+
+### Fixed
+
+- Error log for /alert/sms now has the correct route name
+
 ## [3.3.0] - 2021-05-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -678,8 +678,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#670289913a076d5b2c7c82542a1b7ed28bd9100b",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.2.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#66cb40c57968ffbc69dda09a1b709c8a40619069",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.3.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -1006,9 +1006,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
+      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
     },
     "debug": {
       "version": "4.3.1",
@@ -4035,9 +4035,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.61.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.61.0.tgz",
-      "integrity": "sha512-hSnPvxogJLC6RrAkE1p2COqO6L0TMElImYDaI4eJJAn6EpJhwpHIwulpNH1R11TsJp0f9lqT7VvwYHhVXSvrvw==",
+      "version": "3.63.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.63.0.tgz",
+      "integrity": "sha512-ftZckbTBjJ5dgzdII9j0sqYw9SYq3wqTC9r6NmV7CRU0EXXDil5/AbKb78xNPLtMPx3+mn2N+2oTkQlTtWs9TQ==",
       "requires": {
         "axios": "^0.21.1",
         "dayjs": "^1.8.29",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.2.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.3.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",


### PR DESCRIPTION
- To change `logSentry` to a message instead of an error
- To fix the route in handleTwilioMessage error messages
- ~~Didn't update the CHANGELOG because these two changes are modifications of things that already have an entry in the upcoming release's CHANGELOG.~~

Tested by:
- Deploying to Dev
- Running the smoketests.
- Running the smoketests by replying to the stillness alert using a phone that isn't the Responder phone, which gave me this message: `2021-05-14T02:03:23.945105365Z Bad request to /alert/sms: Invalid Phone Number` 
- Unplugged one of my test devices and saw that it made a Sentry message (not a Sentry exception): `https://sentry.io/organizations/brave-technology-coop/issues/2398137334/?environment=dev-sensor-server&project=3012816&query=is%3Aunresolved` and another one when I reconnected: https://sentry.io/organizations/brave-technology-coop/issues/2398139875/?environment=dev-sensor-server&project=3012816&referrer=alert_email