### PR TITLE
Only update start_times array while we have a lock on sessions (CU-vf7z0f)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the code was deployed.
 
 ### Fixed
 - Helm chart RELEASE variable error when the image tag happened to be an integer.
+- Race condition in auto-reset (CU-vf7z0f).
 
 ## [3.2.0] - 2021-04-26
 

--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ async function autoResetSession(locationid) {
     await db.closeSession(currentSession.sessionid, client)
     await db.updateSessionResetDetails(currentSession.sessionid, 'Auto reset', 'Reset', client)
     redis.addStateMachineData('Reset', locationid)
+    start_times[locationid] = null
     await db.commitTransaction(client)
   } catch (e) {
     helpers.log('Could not reset open session')
@@ -270,10 +271,8 @@ async function handleSensorRequest(currentLocationId, radarType) {
   }
 
   // If session duration is longer than the threshold (20 min), reset the session at this location, send an alert to notify as well.
-
   if (sessionDuration * 1000 > location.autoResetThreshold) {
     autoResetSession(location.locationid)
-    start_times[currentLocationId] = null
     helpers.log(`${currentLocationId}: autoResetSession has been called`)
     sendResetAlert(location.locationid)
   }


### PR DESCRIPTION
- This will prevent a race condition that was causing never-ending
  sessions when a first session (S1) was auto-reset while having
  a lock on the sessions table, but then it gave up its lock before
  setting start_times[locationid] to null for that location. This
  allowed a new session to be created between those two operations
  that then had its start_times[locationid] set to null essentially
  right after it started. This left us in a position where the
  sessionDuration calcuation would return `undefined` and we would
  never auto-reset the new session.

Tested this by:
- Running the smoke tests and replying to all the texts
- Running the smoke tests and not replying to any of the texts in order to see the auto-reset happen.