### PR TITLE
Always send 200 to Particle and reduce thrown errors in DB functions (CU-m0we6c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,16 @@ the code was deployed.
 - Concept of active/inactive locations (CU-rk8axg)
 
 ### Changed
+
 - Improved some API error messages.
 - Heartbeat text now contains troubleshooting instructions and contact email for follow-up. (CU-rx46w0)
 - Do not change state or send alerts for inactive locations (CU-rk8axg)
+- Always return 200 to Particle when it calls our APIs (CU-m0we6c)
 
 ### Fixed
-- Helm chart RELEASE variable error when the image tag happened to be an integer.
-- Race condition in auto-reset (CU-vf7z0f).
+
+- Helm chart RELEASE variable error when the image tag happened to be an integer
+- Race condition in auto-reset (CU-vf7z0f)
 
 ## [3.2.0] - 2021-04-26
 

--- a/db/db.js
+++ b/db/db.js
@@ -63,7 +63,7 @@ async function rollbackTransaction(client) {
 
 async function runQuery(functionName, queryString, queryParams, clientParam) {
   let client = clientParam
-  const transactionMode = typeof client !== 'undefined'
+  const transactionMode = client !== undefined
 
   try {
     if (!transactionMode) {
@@ -104,7 +104,7 @@ async function getMostRecentSession(locationid, clientParam) {
       clientParam,
     )
 
-    if (typeof results === 'undefined') {
+    if (results === undefined || results.rows.length === 0) {
       return null
     }
 
@@ -118,6 +118,10 @@ async function getMostRecentSession(locationid, clientParam) {
 async function getSessionWithSessionId(sessionid, clientParam) {
   try {
     const results = await runQuery('getSessionWithSessionId', 'SELECT * FROM sessions WHERE sessionid = $1', [sessionid], clientParam)
+
+    if (results === undefined || results.rows.length === 0) {
+      return null
+    }
 
     return createSessionFromRow(results.rows[0])
   } catch (err) {
@@ -135,7 +139,7 @@ async function getMostRecentSessionPhone(twilioNumber, clientParam) {
       clientParam,
     )
 
-    if (results === undefined) {
+    if (results === undefined || results.rows.length === 0) {
       return null
     }
 
@@ -154,7 +158,7 @@ async function getHistoryOfSessions(locationid, clientParam) {
       clientParam,
     )
 
-    if (typeof results === 'undefined') {
+    if (results === undefined) {
       return null
     }
 
@@ -437,7 +441,7 @@ async function getLocationData(locationid, clientParam) {
   try {
     const results = await runQuery('getLocationData', 'SELECT * FROM locations WHERE locationid = $1', [locationid], clientParam)
 
-    if (results === undefined) {
+    if (results === undefined || results.rows.length === 0) {
       return null
     }
 
@@ -471,8 +475,8 @@ async function getLocationFromParticleCoreID(coreID, clientParam) {
       [coreID],
       clientParam,
     )
-    if (results === undefined) {
-      helpers.logError('Error: No location with associated coreID exists')
+
+    if (results === undefined || results.rows.length === 0) {
       return null
     }
 
@@ -486,7 +490,7 @@ async function getActiveLocations(clientParam) {
   try {
     const results = await runQuery('getLocations', 'SELECT * FROM locations WHERE is_active', [], clientParam)
 
-    if (typeof results === 'undefined') {
+    if (results === undefined) {
       return null
     }
 
@@ -501,7 +505,7 @@ async function getLocations(clientParam) {
   try {
     const results = await runQuery('getLocations', 'SELECT * FROM locations ORDER BY display_name', [], clientParam)
 
-    if (typeof results === 'undefined') {
+    if (results === undefined) {
       return null
     }
 

--- a/index.js
+++ b/index.js
@@ -713,11 +713,14 @@ app.post('/api/xethru', Validator.body(['locationid', 'state', 'rpm', 'mov_f', '
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)
-      res.status(400).send(errorMessage)
+      // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+      res.status(200).json(errorMessage)
     }
   } catch (err) {
-    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-    res.status(500).send()
+    const errorMessage = `Error calling ${req.path}: ${JSON.stringify(err)}`
+    helpers.logError(errorMessage)
+    // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+    res.status(200).json(errorMessage)
   }
 })
 
@@ -744,7 +747,8 @@ app.post(
         if (!location) {
           const errorMessage = `Bad request to ${request.path}: no location matches the coreID ${coreId}`
           helpers.logError(errorMessage)
-          response.status(400).json(errorMessage)
+          // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+          response.status(200).json(errorMessage)
         } else {
           const data = JSON.parse(request.body.data)
           const inPhase = data.inPhase
@@ -761,11 +765,14 @@ app.post(
       } else {
         const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
         helpers.logError(errorMessage)
-        response.status(400).send(errorMessage)
+        // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+        response.status(200).json(errorMessage)
       }
     } catch (err) {
-      helpers.logError(`Error calling ${request.path}: ${JSON.stringify(err)}`)
-      response.status(500).send()
+      const errorMessage = `Error calling ${request.path}: ${JSON.stringify(err)}`
+      helpers.logError(errorMessage)
+      // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+      response.status(200).json(errorMessage)
     }
   },
 )
@@ -781,7 +788,8 @@ app.post('/api/door', Validator.body(['coreid', 'data']).exists(), async (reques
       if (!location) {
         const errorMessage = `Bad request to ${request.path}: no location matches the coreID ${coreId}`
         helpers.logError(errorMessage)
-        response.status(400).json(errorMessage)
+        // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+        response.status(200).json(errorMessage)
       } else {
         const locationid = location.locationid
         const radarType = location.radarType
@@ -810,11 +818,14 @@ app.post('/api/door', Validator.body(['coreid', 'data']).exists(), async (reques
     } else {
       const errorMessage = `Bad request to ${request.path}: ${validationErrors.array()}`
       helpers.logError(errorMessage)
-      response.status(400).send(errorMessage)
+      // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+      response.status(200).json(errorMessage)
     }
   } catch (err) {
-    helpers.logError(`Error calling ${request.path}: ${JSON.stringify(err)}`)
-    response.status(500).send()
+    const errorMessage = `Error calling ${request.path}: ${JSON.stringify(err)}`
+    helpers.logError(errorMessage)
+    // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
+    response.status(200).json(errorMessage)
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -289,12 +289,9 @@ async function handleSensorRequest(location, radarType) {
         client = await db.beginTransaction()
         const latestSession = await db.getMostRecentSession(location.locationid, client)
 
-        if (typeof latestSession !== 'undefined') {
-          // Checks if no session exists for this location yet.
-          if (latestSession.endTime == null) {
-            // Checks if session is open.
-            await db.updateSessionState(latestSession.sessionid, currentState, client)
-          }
+        // If there is an open session for this location
+        if (latestSession !== null && latestSession.endTime === null) {
+          await db.updateSessionState(latestSession.sessionid, currentState, client)
         }
         await db.commitTransaction(client)
       } catch (e) {
@@ -312,7 +309,7 @@ async function handleSensorRequest(location, radarType) {
         client = await db.beginTransaction()
         const latestSession = await db.getMostRecentSession(location.locationid, client)
 
-        if (typeof latestSession !== 'undefined') {
+        if (latestSession !== null) {
           // Checks if session exists
           if (latestSession.endTime == null) {
             // Checks if session is open for this location
@@ -386,7 +383,7 @@ async function handleSensorRequest(location, radarType) {
     const currentSession = await db.getMostRecentSession(location.locationid)
 
     // Checks if session is in the STILL state and, if so, how long it has been in that state for.
-    if (typeof currentSession !== 'undefined') {
+    if (currentSession !== null) {
       if (currentSession.state === 'Still' || currentSession.state === 'Breathing') {
         if (currentSession.endTime == null) {
           // Only increases counter if session is open
@@ -456,7 +453,7 @@ app.get('/dashboard', sessionChecker, async (req, res) => {
 
     for (const location of allLocations) {
       const recentSession = await db.getMostRecentSession(location.locationid)
-      if (recentSession) {
+      if (recentSession !== null) {
         const sessionStartTime = Date.parse(recentSession.startTime)
         const timeSinceLastSession = await generateCalculatedTimeDifferenceString(sessionStartTime)
         location.sessionStart = timeSinceLastSession

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -158,12 +158,12 @@ describe('Brave Sensor server', () => {
       helpers.log('\n')
     })
 
-    it('should return 400 to a im21 door signal with an unregistered coreID', async () => {
+    it('should return 200 to a im21 door signal with an unregistered coreID', async () => {
       const response = await chai
         .request(server)
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
+      expect(response).to.have.status(200)
     })
 
     it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
@@ -281,12 +281,12 @@ describe('Brave Sensor server', () => {
       helpers.log('\n')
     })
 
-    it('should return 400 to a im21 door signal with an unregistered coreID', async () => {
+    it('should return 200 to a im21 door signal with an unregistered coreID', async () => {
       const response = await chai
         .request(server)
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
+      expect(response).to.have.status(200)
     })
 
     it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
@@ -358,12 +358,12 @@ describe('Brave Sensor server', () => {
       helpers.log('\n')
     })
 
-    it('should return 400 to a im21 door signal with an unregistered coreID', async () => {
+    it('should return 200 to a im21 door signal with an unregistered coreID', async () => {
       const response = await chai
         .request(server)
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
+      expect(response).to.have.status(200)
     })
 
     it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
@@ -483,12 +483,12 @@ describe('Brave Sensor server', () => {
       helpers.log('\n')
     })
 
-    it('should return 400 to a im21 door signal with an unregistered coreID', async () => {
+    it('should return 200 to a im21 door signal with an unregistered coreID', async () => {
       const response = await chai
         .request(server)
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
+      expect(response).to.have.status(200)
     })
 
     it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
@@ -570,22 +570,22 @@ describe('Brave Sensor server', () => {
         expect(response).to.have.status(200)
       })
 
-      it('should return 400 for a request that does not contain coreid', async () => {
+      it('should return 200 for a request that does not contain coreid', async () => {
         const badRequest = {
           data: `{ "data": "${IM21_DOOR_STATUS.CLOSED}", "control": "86"}`,
         }
 
         const response = await chai.request(server).post('/api/door').send(badRequest)
-        expect(response).to.have.status(400)
+        expect(response).to.have.status(200)
       })
 
-      it('should return 400 for a request that does not contain data', async () => {
+      it('should return 200 for a request that does not contain data', async () => {
         const badRequest = {
           coreid: door_coreID,
         }
 
         const response = await chai.request(server).post('/api/door').send(badRequest)
-        expect(response).to.have.status(400)
+        expect(response).to.have.status(200)
       })
     })
 


### PR DESCRIPTION
**Change all endpoints that Particle uses to always return 200**
- Apparently Particle throttles sending messages when it returns too
  many 400s and 500s. So to make sure that we're getting all the
  message, and since we don't actually do anything with the return
  status/message anyways, it seems to make sense to return 200 and
  not worry about it.
- Ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits

**Reduce thrown errors in DB functions**
- A few of our DB functions are supposed to return a single object (Location or Session), which means that they use `results.rows[0]`. But if there were no results from the query, there is no `results.rows[0]`, thus throwing an error. Which is  then immediately caught and the very un-helpful error message `{}` is output to the logs.
- Now all of these functions check for this case and consistently return `null`
- Had to update some of the checks for the return value to check for `null` now instead of `undefined`

What I did to test this on `dev.sensors.brave.coop`:
- Ran smoke tests
- Watched the logs while there is an INS sending messages that is not in the `Locations` table. They are now all coming in at a 2-second interval as expected.
- Started a real session in my bathroom with my INS while there is another INS sending messages that are not in the `Locations` table. Saw that my movement and stillness were coming in frequently at 2-second intervals (we don't expect this always since it should only log when there is a change of state)
- Looked at the Cluster Insights in Digital Ocean and didn't see anything strange. But also didn't see anything strange while it was working incorrectly.