### PR TITLE
Add mass notification feature to Dashboard (CU-w9bcb5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ the code was deployed.
 
 ### Added
 
-- Storing and checking for door heartbeat messages (CU-wf97dy).
+- Storing and checking for door heartbeat messages (CU-wf97dy)
+- New Notification page on the Dashboard (CU-w9bcb5)
 
 ### Changed
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,380 @@
+// Third-party dependencies
+const cookieParser = require('cookie-parser')
+const fs = require('fs')
+const moment = require('moment-timezone')
+const session = require('express-session')
+const Mustache = require('mustache')
+const Validator = require('express-validator')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+const db = require('./db/db.js')
+
+const locationsDashboardTemplate = fs.readFileSync(`${__dirname}/mustache-templates/locationsDashboard.mst`, 'utf-8')
+const landingPageTemplate = fs.readFileSync(`${__dirname}/mustache-templates/landingPage.mst`, 'utf-8')
+const navPartial = fs.readFileSync(`${__dirname}/mustache-templates/navPartial.mst`, 'utf-8')
+const landingCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/landingCSSPartial.mst`, 'utf-8')
+const locationsCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/locationsCSSPartial.mst`, 'utf-8')
+const newLocationTemplate = fs.readFileSync(`${__dirname}/mustache-templates/newLocation.mst`, 'utf-8')
+const updateLocationTemplate = fs.readFileSync(`${__dirname}/mustache-templates/updateLocation.mst`, 'utf-8')
+const locationFormCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/locationFormCSSPartial.mst`, 'utf-8')
+
+async function generateCalculatedTimeDifferenceString(timeToCompare) {
+  const daySecs = 24 * 60 * 60
+  const hourSecs = 60 * 60
+  const minSecs = 60
+  let returnString = ''
+  let numDays = 0
+  let numHours = 0
+  let numMins = 0
+  const currentTime = await db.getCurrentTime()
+
+  let diffSecs = (currentTime - timeToCompare) / 1000
+
+  if (diffSecs >= daySecs) {
+    numDays = Math.floor(diffSecs / daySecs)
+    diffSecs %= daySecs
+  }
+  returnString += `${numDays} ${numDays === 1 ? 'day, ' : 'days, '}`
+
+  if (diffSecs >= hourSecs) {
+    numHours = Math.floor(diffSecs / hourSecs)
+    diffSecs %= hourSecs
+  }
+  returnString += `${numHours} ${numHours === 1 ? 'hour, ' : 'hours, '}`
+
+  if (diffSecs >= minSecs) {
+    numMins = Math.floor(diffSecs / minSecs)
+  }
+  returnString += `${numMins} ${numMins === 1 ? 'minute' : 'minutes'}`
+
+  if (numDays + numHours === 0) {
+    diffSecs %= minSecs
+    const numSecs = Math.floor(diffSecs)
+
+    returnString += `, ${numSecs} ${numSecs === 1 ? 'second' : 'seconds'}`
+  }
+
+  returnString += ' ago'
+
+  return returnString
+}
+
+function setupDashboardSessions(app) {
+  app.use(cookieParser())
+
+  // initialize express-session to allow us track the logged-in user across sessions.
+  app.use(
+    session({
+      key: 'user_sid',
+      secret: helpers.getEnvVar('SECRET'),
+      resave: false,
+      saveUninitialized: false,
+      cookie: {
+        expires: 8 * 60 * 60 * 1000,
+      },
+    }),
+  )
+
+  // This middleware will check if user's cookie is still saved in browser and user is not set, then automatically log the user out.
+  // This usually happens when you stop your express server after login, your cookie still remains saved in the browser.
+  app.use((req, res, next) => {
+    if (req.cookies.user_sid && !req.session.user) {
+      res.clearCookie('user_sid')
+    }
+    next()
+  })
+}
+
+// middleware function to check for logged-in users
+function sessionChecker(req, res, next) {
+  if (!req.session.user || !req.cookies.user_sid) {
+    res.redirect('/login')
+  } else {
+    next()
+  }
+}
+
+function redirectToHomePage(req, res) {
+  res.redirect('/dashboard')
+}
+
+function renderLoginPage(req, res) {
+  res.sendFile(`${__dirname}/login.html`)
+}
+
+function submitLogin(req, res) {
+  const username = req.body.username
+  const password = req.body.password
+
+  if (username === helpers.getEnvVar('WEB_USERNAME') && password === helpers.getEnvVar('PASSWORD')) {
+    req.session.user = username
+    res.redirect('/dashboard')
+  } else {
+    res.redirect('/login')
+  }
+}
+
+function submitLogout(req, res) {
+  if (req.session.user && req.cookies.user_sid) {
+    res.clearCookie('user_sid')
+    res.redirect('/')
+  } else {
+    res.redirect('/login')
+  }
+}
+
+async function renderLandingPage(req, res) {
+  try {
+    const allLocations = await db.getLocations()
+
+    for (const location of allLocations) {
+      const recentSession = await db.getMostRecentSession(location.locationid)
+      if (recentSession !== null) {
+        const sessionStartTime = Date.parse(recentSession.startTime)
+        const timeSinceLastSession = await generateCalculatedTimeDifferenceString(sessionStartTime)
+        location.sessionStart = timeSinceLastSession
+      }
+    }
+
+    const viewParams = {
+      locations: allLocations.map(location => {
+        return { name: location.displayName, id: location.locationid, sessionStart: location.sessionStart, isActive: location.isActive }
+      }),
+    }
+
+    res.send(Mustache.render(landingPageTemplate, viewParams, { nav: navPartial, css: landingCSSPartial }))
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+async function renderNewLocationPage(req, res) {
+  try {
+    const allLocations = await db.getLocations()
+
+    const viewParams = {
+      locations: allLocations.map(location => {
+        return { name: location.displayName, id: location.locationid }
+      }),
+    }
+
+    res.send(Mustache.render(newLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+async function renderLocationDetailsPage(req, res) {
+  try {
+    const recentSessions = await db.getHistoryOfSessions(req.params.locationId)
+    const allLocations = await db.getLocations()
+    const currentLocation = allLocations.find(location => location.locationid === req.params.locationId)
+
+    const viewParams = {
+      recentSessions: [],
+      currentLocation,
+      locations: allLocations.map(location => {
+        return { name: location.displayName, id: location.locationid }
+      }),
+    }
+
+    // commented out keys were not shown on the old frontend but have been included in case that changes
+    for (const recentSession of recentSessions) {
+      const startTime = moment(recentSession.startTime, moment.ISO_8601).tz('America/Vancouver').format('DD MMM Y, hh:mm:ss A')
+      const endTime = recentSession.endTime
+        ? moment(recentSession.endTime, moment.ISO_8601).tz('America/Vancouver').format('DD MMM Y, hh:mm:ss A')
+        : 'Ongoing'
+
+      viewParams.recentSessions.push({
+        startTime,
+        endTime,
+        state: recentSession.state,
+        notes: recentSession.notes,
+        incidentType: recentSession.incidentType,
+        sessionid: recentSession.sessionid,
+        duration: recentSession.duration,
+        chatbotState: recentSession.chatbotState,
+        // alertReason: recentSession.alertReason,
+      })
+    }
+
+    res.send(Mustache.render(locationsDashboardTemplate, viewParams, { nav: navPartial, css: locationsCSSPartial }))
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+async function renderLocationEditPage(req, res) {
+  try {
+    const allLocations = await db.getLocations()
+    const currentLocation = allLocations.find(location => location.locationid === req.params.locationId)
+
+    // for the dropdown in the edit screen so it does not display duplicate options
+    if (currentLocation.radarType === 'XeThru') {
+      currentLocation.otherType = 'Innosent'
+    } else {
+      currentLocation.otherType = 'XeThru'
+    }
+
+    const viewParams = {
+      currentLocation,
+      locations: allLocations.map(location => {
+        return { name: location.displayName, id: location.locationid }
+      }),
+    }
+
+    res.send(Mustache.render(updateLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+const validateNewLocation = [
+  Validator.body(['locationid', 'displayName', 'doorCoreID', 'radarCoreID', 'radarType', 'twilioPhone']).notEmpty(),
+  Validator.oneOf([Validator.body(['phone']).notEmpty(), Validator.body(['alertApiKey']).notEmpty()]),
+]
+
+async function submitNewLocation(req, res) {
+  try {
+    if (!req.session.user || !req.cookies.user_sid) {
+      helpers.logError('Unauthorized')
+      res.status(401).send()
+      return
+    }
+
+    const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+    if (validationErrors.isEmpty()) {
+      const allLocations = await db.getLocations()
+      const data = req.body
+
+      for (const location of allLocations) {
+        if (location.locationid === data.locationid) {
+          helpers.log('Location ID already exists')
+          return res.status(409).send('Location ID already exists')
+        }
+      }
+
+      await db.createLocationFromBrowserForm(
+        data.locationid,
+        data.displayName,
+        data.doorCoreID,
+        data.radarCoreID,
+        data.radarType,
+        data.phone,
+        data.twilioPhone,
+        data.alertApiKey,
+      )
+
+      res.redirect(`/locations/${data.locationid}`)
+    } else {
+      const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
+      helpers.logError(errorMessage)
+      res.status(400).send(errorMessage)
+    }
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+const validateEditLocation = [
+  Validator.body([
+    'displayName',
+    'doorCoreID',
+    'radarCoreID',
+    'radarType',
+    'fallbackPhones',
+    'heartbeatPhones',
+    'twilioPhone',
+    'sensitivity',
+    'led',
+    'noiseMap',
+    'movThreshold',
+    'rpmThreshold',
+    'durationThreshold',
+    'stillThreshold',
+    'autoResetThreshold',
+    'doorDelay',
+    'reminderTimer',
+    'fallbackTimer',
+    'isActive',
+  ]).notEmpty(),
+  Validator.oneOf([Validator.body(['phone']).notEmpty(), Validator.body(['alertApiKey']).notEmpty()]),
+]
+
+async function submitEditLocation(req, res) {
+  try {
+    if (!req.session.user || !req.cookies.user_sid) {
+      helpers.logError('Unauthorized')
+      res.status(401).send()
+      return
+    }
+
+    const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+    if (validationErrors.isEmpty()) {
+      const data = req.body
+      data.locationid = req.params.locationId
+
+      const newAlertApiKey = data.alertApiKey && data.alertApiKey.trim() !== '' ? data.alertApiKey : null
+      const newPhone = data.phone && data.phone.trim() !== '' ? data.phone : null
+
+      await db.updateLocation(
+        data.displayName,
+        data.doorCoreID,
+        data.radarCoreID,
+        data.radarType,
+        newPhone,
+        data.fallbackPhones.split(','),
+        data.heartbeatPhones.split(','),
+        data.twilioPhone,
+        data.sensitivity,
+        data.led,
+        data.noiseMap,
+        data.movThreshold,
+        data.rpmThreshold,
+        data.durationThreshold,
+        data.stillThreshold,
+        data.autoResetThreshold,
+        data.doorDelay,
+        data.reminderTimer,
+        data.fallbackTimer,
+        newAlertApiKey,
+        data.isActive === 'true',
+        data.locationid,
+      )
+
+      res.redirect(`/locations/${data.locationid}`)
+    } else {
+      const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
+      helpers.logError(errorMessage)
+      res.status(400).send(errorMessage)
+    }
+  } catch (err) {
+    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
+    res.status(500).send()
+  }
+}
+
+module.exports = {
+  redirectToHomePage,
+  renderLandingPage,
+  renderLocationDetailsPage,
+  renderLocationEditPage,
+  renderLoginPage,
+  renderNewLocationPage,
+  sessionChecker,
+  setupDashboardSessions,
+  submitEditLocation,
+  submitLogin,
+  submitLogout,
+  submitNewLocation,
+  validateEditLocation,
+  validateNewLocation,
+}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 const express = require('express')
 const fs = require('fs')
 const https = require('https')
-const moment = require('moment-timezone')
 const bodyParser = require('body-parser')
 const cors = require('cors')
 const Validator = require('express-validator')

--- a/index.js
+++ b/index.js
@@ -4,17 +4,15 @@ const fs = require('fs')
 const https = require('https')
 const moment = require('moment-timezone')
 const bodyParser = require('body-parser')
-const session = require('express-session')
-const cookieParser = require('cookie-parser')
 const cors = require('cors')
-const routes = require('express').Router()
-const Mustache = require('mustache')
 const Validator = require('express-validator')
 
 // In-house dependencies
 const { helpers } = require('brave-alert-lib')
+const routes = require('./routes.js')
 const redis = require('./db/redis.js')
 const db = require('./db/db.js')
+const dashboard = require('./dashboard.js')
 const XeThruStateMachine = require('./XeThruStateMachine.js')
 const InnosentStateMachine = require('./InnosentStateMachine.js')
 const STATE = require('./SessionStateEnum.js')
@@ -24,15 +22,6 @@ const IM21_DOOR_STATUS = require('./IM21DoorStatusEnum')
 const SESSIONSTATE_DOOR = require('./SessionStateDoorEnum')
 
 const WATCHDOG_TIMER_FREQUENCY = 60 * 1000
-
-const locationsDashboardTemplate = fs.readFileSync(`${__dirname}/mustache-templates/locationsDashboard.mst`, 'utf-8')
-const landingPageTemplate = fs.readFileSync(`${__dirname}/mustache-templates/landingPage.mst`, 'utf-8')
-const navPartial = fs.readFileSync(`${__dirname}/mustache-templates/navPartial.mst`, 'utf-8')
-const landingCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/landingCSSPartial.mst`, 'utf-8')
-const locationsCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/locationsCSSPartial.mst`, 'utf-8')
-const newLocationTemplate = fs.readFileSync(`${__dirname}/mustache-templates/newLocation.mst`, 'utf-8')
-const updateLocationTemplate = fs.readFileSync(`${__dirname}/mustache-templates/updateLocation.mst`, 'utf-8')
-const locationFormCSSPartial = fs.readFileSync(`${__dirname}/mustache-templates/locationFormCSSPartial.mst`, 'utf-8')
 
 // Start Express App
 const app = express()
@@ -69,65 +58,11 @@ app.use(express.json())
 // Cors Middleware (Cross Origin Resource Sharing)
 app.use(cors())
 
-app.use(cookieParser())
-
-// initialize express-session to allow us track the logged-in user across sessions.
-app.use(
-  session({
-    key: 'user_sid',
-    secret: helpers.getEnvVar('SECRET'),
-    resave: false,
-    saveUninitialized: false,
-    cookie: {
-      expires: 8 * 60 * 60 * 1000,
-    },
-  }),
-)
-
 function convertToSeconds(milliseconds) {
   return Math.floor(milliseconds / 1000)
 }
 
-async function generateCalculatedTimeDifferenceString(timeToCompare) {
-  const daySecs = 24 * 60 * 60
-  const hourSecs = 60 * 60
-  const minSecs = 60
-  let returnString = ''
-  let numDays = 0
-  let numHours = 0
-  let numMins = 0
-  const currentTime = await db.getCurrentTime()
-
-  let diffSecs = (currentTime - timeToCompare) / 1000
-
-  if (diffSecs >= daySecs) {
-    numDays = Math.floor(diffSecs / daySecs)
-    diffSecs %= daySecs
-  }
-  returnString += `${numDays} ${numDays === 1 ? 'day, ' : 'days, '}`
-
-  if (diffSecs >= hourSecs) {
-    numHours = Math.floor(diffSecs / hourSecs)
-    diffSecs %= hourSecs
-  }
-  returnString += `${numHours} ${numHours === 1 ? 'hour, ' : 'hours, '}`
-
-  if (diffSecs >= minSecs) {
-    numMins = Math.floor(diffSecs / minSecs)
-  }
-  returnString += `${numMins} ${numMins === 1 ? 'minute' : 'minutes'}`
-
-  if (numDays + numHours === 0) {
-    diffSecs %= minSecs
-    const numSecs = Math.floor(diffSecs)
-
-    returnString += `, ${numSecs} ${numSecs === 1 ? 'second' : 'seconds'}`
-  }
-
-  returnString += ' ago'
-
-  return returnString
-}
+dashboard.setupDashboardSessions(app)
 
 // Closes any open session and resets state for the given location
 async function autoResetSession(locationid) {
@@ -415,297 +350,8 @@ async function handleSensorRequest(location, radarType) {
   }
 }
 
-// This middleware will check if user's cookie is still saved in browser and user is not set, then automatically log the user out.
-// This usually happens when you stop your express server after login, your cookie still remains saved in the browser.
-app.use((req, res, next) => {
-  if (req.cookies.user_sid && !req.session.user) {
-    res.clearCookie('user_sid')
-  }
-  next()
-})
-
-// middleware function to check for logged-in users
-function sessionChecker(req, res, next) {
-  if (!req.session.user || !req.cookies.user_sid) {
-    res.redirect('/login')
-  } else {
-    next()
-  }
-}
-
-app.get('/', sessionChecker, (req, res) => {
-  res.redirect('/dashboard')
-})
-
-app
-  .route('/login')
-  .get((req, res) => {
-    res.sendFile(`${__dirname}/login.html`)
-  })
-  .post((req, res) => {
-    const username = req.body.username
-    const password = req.body.password
-
-    if (username === helpers.getEnvVar('WEB_USERNAME') && password === helpers.getEnvVar('PASSWORD')) {
-      req.session.user = username
-      res.redirect('/dashboard')
-    } else {
-      res.redirect('/login')
-    }
-  })
-
-app.get('/logout', (req, res) => {
-  if (req.session.user && req.cookies.user_sid) {
-    res.clearCookie('user_sid')
-    res.redirect('/')
-  } else {
-    res.redirect('/login')
-  }
-})
-
-app.get('/dashboard', sessionChecker, async (req, res) => {
-  try {
-    const allLocations = await db.getLocations()
-
-    for (const location of allLocations) {
-      const recentSession = await db.getMostRecentSession(location.locationid)
-      if (recentSession !== null) {
-        const sessionStartTime = Date.parse(recentSession.startTime)
-        const timeSinceLastSession = await generateCalculatedTimeDifferenceString(sessionStartTime)
-        location.sessionStart = timeSinceLastSession
-      }
-    }
-
-    const viewParams = {
-      locations: allLocations.map(location => {
-        return { name: location.displayName, id: location.locationid, sessionStart: location.sessionStart, isActive: location.isActive }
-      }),
-    }
-
-    res.send(Mustache.render(landingPageTemplate, viewParams, { nav: navPartial, css: landingCSSPartial }))
-  } catch (err) {
-    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-    res.status(500).send()
-  }
-})
-
-app.get('/locations/new', sessionChecker, async (req, res) => {
-  try {
-    const allLocations = await db.getLocations()
-
-    const viewParams = {
-      locations: allLocations.map(location => {
-        return { name: location.displayName, id: location.locationid }
-      }),
-    }
-
-    res.send(Mustache.render(newLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))
-  } catch (err) {
-    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-    res.status(500).send()
-  }
-})
-
-app.get('/locations/:locationId', sessionChecker, async (req, res) => {
-  try {
-    const recentSessions = await db.getHistoryOfSessions(req.params.locationId)
-    const allLocations = await db.getLocations()
-    const currentLocation = allLocations.find(location => location.locationid === req.params.locationId)
-
-    const viewParams = {
-      recentSessions: [],
-      currentLocation,
-      locations: allLocations.map(location => {
-        return { name: location.displayName, id: location.locationid }
-      }),
-    }
-
-    // commented out keys were not shown on the old frontend but have been included in case that changes
-    for (const recentSession of recentSessions) {
-      const startTime = moment(recentSession.startTime, moment.ISO_8601).tz('America/Vancouver').format('DD MMM Y, hh:mm:ss A')
-      const endTime = recentSession.endTime
-        ? moment(recentSession.endTime, moment.ISO_8601).tz('America/Vancouver').format('DD MMM Y, hh:mm:ss A')
-        : 'Ongoing'
-
-      viewParams.recentSessions.push({
-        startTime,
-        endTime,
-        state: recentSession.state,
-        notes: recentSession.notes,
-        incidentType: recentSession.incidentType,
-        sessionid: recentSession.sessionid,
-        duration: recentSession.duration,
-        chatbotState: recentSession.chatbotState,
-        // alertReason: recentSession.alertReason,
-      })
-    }
-
-    res.send(Mustache.render(locationsDashboardTemplate, viewParams, { nav: navPartial, css: locationsCSSPartial }))
-  } catch (err) {
-    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-    res.status(500).send()
-  }
-})
-
-app.get('/locations/:locationId/edit', sessionChecker, async (req, res) => {
-  try {
-    const allLocations = await db.getLocations()
-    const currentLocation = allLocations.find(location => location.locationid === req.params.locationId)
-
-    // for the dropdown in the edit screen so it does not display duplicate options
-    if (currentLocation.radarType === 'XeThru') {
-      currentLocation.otherType = 'Innosent'
-    } else {
-      currentLocation.otherType = 'XeThru'
-    }
-
-    const viewParams = {
-      currentLocation,
-      locations: allLocations.map(location => {
-        return { name: location.displayName, id: location.locationid }
-      }),
-    }
-
-    res.send(Mustache.render(updateLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))
-  } catch (err) {
-    helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-    res.status(500).send()
-  }
-})
-
-// Post routes for new add/update location forms
-
-app.post(
-  '/locations',
-  [
-    Validator.body(['locationid', 'displayName', 'doorCoreID', 'radarCoreID', 'radarType', 'twilioPhone']).notEmpty(),
-    Validator.oneOf([Validator.body(['phone']).notEmpty(), Validator.body(['alertApiKey']).notEmpty()]),
-  ],
-  async (req, res) => {
-    try {
-      if (!req.session.user || !req.cookies.user_sid) {
-        helpers.logError('Unauthorized')
-        res.status(401).send()
-        return
-      }
-
-      const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
-
-      if (validationErrors.isEmpty()) {
-        const allLocations = await db.getLocations()
-        const data = req.body
-
-        for (const location of allLocations) {
-          if (location.locationid === data.locationid) {
-            helpers.log('Location ID already exists')
-            return res.status(409).send('Location ID already exists')
-          }
-        }
-
-        await db.createLocationFromBrowserForm(
-          data.locationid,
-          data.displayName,
-          data.doorCoreID,
-          data.radarCoreID,
-          data.radarType,
-          data.phone,
-          data.twilioPhone,
-          data.alertApiKey,
-        )
-
-        res.redirect(`/locations/${data.locationid}`)
-      } else {
-        const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-        helpers.logError(errorMessage)
-        res.status(400).send(errorMessage)
-      }
-    } catch (err) {
-      helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-      res.status(500).send()
-    }
-  },
-)
-
-app.post(
-  '/locations/:locationId',
-  [
-    Validator.body([
-      'displayName',
-      'doorCoreID',
-      'radarCoreID',
-      'radarType',
-      'fallbackPhones',
-      'heartbeatPhones',
-      'twilioPhone',
-      'sensitivity',
-      'led',
-      'noiseMap',
-      'movThreshold',
-      'rpmThreshold',
-      'durationThreshold',
-      'stillThreshold',
-      'autoResetThreshold',
-      'doorDelay',
-      'reminderTimer',
-      'fallbackTimer',
-      'isActive',
-    ]).notEmpty(),
-    Validator.oneOf([Validator.body(['phone']).notEmpty(), Validator.body(['alertApiKey']).notEmpty()]),
-  ],
-  async (req, res) => {
-    try {
-      if (!req.session.user || !req.cookies.user_sid) {
-        helpers.logError('Unauthorized')
-        res.status(401).send()
-        return
-      }
-
-      const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
-
-      if (validationErrors.isEmpty()) {
-        const data = req.body
-        data.locationid = req.params.locationId
-
-        const newAlertApiKey = data.alertApiKey && data.alertApiKey.trim() !== '' ? data.alertApiKey : null
-        const newPhone = data.phone && data.phone.trim() !== '' ? data.phone : null
-
-        await db.updateLocation(
-          data.displayName,
-          data.doorCoreID,
-          data.radarCoreID,
-          data.radarType,
-          newPhone,
-          data.fallbackPhones.split(','),
-          data.heartbeatPhones.split(','),
-          data.twilioPhone,
-          data.sensitivity,
-          data.led,
-          data.noiseMap,
-          data.movThreshold,
-          data.rpmThreshold,
-          data.durationThreshold,
-          data.stillThreshold,
-          data.autoResetThreshold,
-          data.doorDelay,
-          data.reminderTimer,
-          data.fallbackTimer,
-          newAlertApiKey,
-          data.isActive === 'true',
-          data.locationid,
-        )
-
-        res.redirect(`/locations/${data.locationid}`)
-      } else {
-        const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-        helpers.logError(errorMessage)
-        res.status(400).send(errorMessage)
-      }
-    } catch (err) {
-      helpers.logError(`Error calling ${req.path}: ${JSON.stringify(err)}`)
-      res.status(500).send()
-    }
-  },
-)
+// Add routes
+routes.configureRoutes(app)
 
 // Add BraveAlerter's routes ( /alert/* )
 app.use(braveAlerter.getRouter())
@@ -952,5 +598,4 @@ if (helpers.isTestEnvironment()) {
 
 module.exports.server = server
 module.exports.db = db
-module.exports.routes = routes
 module.exports.redis = redis

--- a/mustache-templates/navPartial.mst
+++ b/mustache-templates/navPartial.mst
@@ -26,6 +26,11 @@
             </li>
             <li class="nav-item">
                 <button class="btn btn-logout">
+                    <a href="/notifications/new" class="text-decoration-none">New Notification</a>
+                </button>
+            </li>
+            <li class="nav-item">
+                <button class="btn btn-logout">
                     <a href="/logout" class="text-decoration-none">Log Out</a>
                 </button>
             </li>

--- a/mustache-templates/newNotification.mst
+++ b/mustache-templates/newNotification.mst
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <title>Brave Sensor Dashboard: New Notification</title>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link href="https://fonts.googleapis.com/css?family=Montserrat" rel="stylesheet">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+
+    {{> css}}
+</head>
+
+<body>
+    {{> nav}}
+    <div class="content-area">
+        <div class="content-wrapper">
+            <h4 class="no-locations">Send a Notification</h4>
+            <h6> Please fill in the form below to send a notification to all Locations' responder devices.</h6>
+            <br>
+            <form class="needs-validation" action="/notifications" method="POST">
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="subject" class="col-sm-3 col-form-label">Subject:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="subject" placeholder="Subject">
+                        <small id="subjectHelp" class="form-text text-muted">Not required. For text messages, this will appear at the beginning, followed by a colon and a newline.</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="body" class="col-sm-3 col-form-label">Body:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="body" placeholder="Display Name" required>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="sendToInactive" class="col-sm-3 col-form-label">Also send to inactive Locations?</label>
+                    <div class="col-sm-5">
+                        <input type="checkbox" id="sendToInactive" name="sendToInactive" value="true">
+                    </div>
+                </div>
+                <br>
+                <button type="submit" class="btn btn-primary btn-large">Submit</button>
+              </form>
+        </div>
+    </div>
+    
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/mustache-templates/notificationFormCSSPartial.mst
+++ b/mustache-templates/notificationFormCSSPartial.mst
@@ -1,0 +1,109 @@
+<style>
+    body {
+        background-color: rgb(247, 249, 250);
+        margin: 0px;
+        font-family: 'Montserrat', sans-serif;
+    }
+
+    .navbar-toggler {
+        border: 2px solid rgba(255, 255, 255, .4);
+        border-radius: 5px;
+    }
+
+    .navbar, .btn-logout {
+        background-color: rgb(0, 184, 184);
+        font-size: 20px;
+    }
+
+    .nav-item a {
+        color: rgb(247, 249, 250);
+    }
+
+    .dropdown,
+    .dropdown-toggle,
+    .dropdown-menu {
+        width: 100%;	
+    }
+
+    .nav-link.dropdown-item {
+        color: rgb(88, 88, 91);
+        overflow: hidden; 
+        white-space: nowrap; 
+        text-overflow: ellipsis;
+    }
+
+    .no-locations {
+        opacity: .75;
+    }
+
+    .btn-logout, .btn-logout > a {
+        width: auto;
+        text-decoration: none;
+    }    
+
+    #navbar-brand {
+        font-size: 24px;
+        color: rgb(247, 249, 250);
+    }
+
+    .content-area {
+        background-color: rgb(247, 249, 250);
+        color: rgb(88, 88, 91);
+    }
+
+    .content-wrapper {
+        margin-left: 7%;
+        margin-right: 7%;
+        margin-top: 5%;
+        margin-bottom: 5%;
+    }
+
+    @media screen and (max-width: 770px) {
+
+        .navbar, .btn-logout, h3 {
+            font-size: 1em; 
+            font-weight: 900;
+        }
+
+        #navbar-brand {
+            font-size: 4.5vw;
+            font-weight: 700;
+        }
+
+        .nav-item {
+            text-align: right;
+        }
+
+        .navbar-toggler {
+            border: none;
+        }
+
+        .dropdown-menu {
+            background-color: rgb(0, 184, 184);
+            border: none;
+            padding-right: 3%;
+        }
+
+        .nav-link.dropdown-item {
+            color: rgb(247, 249, 250);
+            text-align: right;
+        }
+
+        .nav-link.dropdown-item:hover {
+            color: white;
+            background-color: rgb(0, 200, 200);
+        }
+
+        .dropdown-menu.show {
+            padding-top: 0%;
+        }
+
+        .btn-logout {
+            padding-right: 0%;
+        }
+
+        table {
+            font-size: 1.8vw;
+        }
+    }
+</style>

--- a/routes.js
+++ b/routes.js
@@ -1,0 +1,20 @@
+const dashboard = require('./dashboard.js')
+
+function configureRoutes(app) {
+  app.get('/', dashboard.sessionChecker, dashboard.redirectToHomePage)
+  app.get('/dashboard', dashboard.sessionChecker, dashboard.renderLandingPage)
+  app.get('/locations/new', dashboard.sessionChecker, dashboard.renderNewLocationPage) // Must be configured before /locations/:locationId
+  app.get('/locations/:locationId', dashboard.sessionChecker, dashboard.renderLocationDetailsPage)
+  app.get('/locations/:locationId/edit', dashboard.sessionChecker, dashboard.renderLocationEditPage)
+  app.get('/login', dashboard.renderLoginPage)
+  app.get('/logout', dashboard.submitLogout)
+
+  app.post('/locations', dashboard.validateNewLocation, dashboard.submitNewLocation)
+  app.post('/locations/:locationId', dashboard.validateEditLocation, dashboard.submitEditLocation)
+  app.post('/login', dashboard.submitLogin)
+  // TODO add the other POST routes here
+}
+
+module.exports = {
+  configureRoutes,
+}

--- a/routes.js
+++ b/routes.js
@@ -8,10 +8,12 @@ function configureRoutes(app) {
   app.get('/locations/:locationId/edit', dashboard.sessionChecker, dashboard.renderLocationEditPage)
   app.get('/login', dashboard.renderLoginPage)
   app.get('/logout', dashboard.submitLogout)
+  app.get('/notifications/new', dashboard.sessionChecker, dashboard.renderNewNotificationPage)
 
   app.post('/locations', dashboard.validateNewLocation, dashboard.submitNewLocation)
   app.post('/locations/:locationId', dashboard.validateEditLocation, dashboard.submitEditLocation)
   app.post('/login', dashboard.submitLogin)
+  app.post('/notifications', dashboard.validateNewNotification, dashboard.submitNewNotification)
   // TODO add the other POST routes here
 }
 


### PR DESCRIPTION
- Added a "New Notification" screen to the Dashboard. Using it will send a message to all the Responder Phones using the `sendSingleAlert` function in `brave-alert-lib`. 
- By default, it will only send to Responder Phones of Active locations. But if you check the checkbox on the New Notification screen, it will also send to Inactive locations.
- The Subject field is not required. If it is provided and if this will be a text notification, it will be pre-pended to the message with a colon and newline. This is here because when we move to Notifications in the Alert App, the design expects there to be a Subject field (see the [Figma](https://www.figma.com/file/GBEb8H6wEuUGZgvx0Gylzt/BRAVE))
- Moved dashboard-related config and routes to own file in an attempt to start splitting up index.js into smaller, more descriptive files