### PR TITLE
Add VSCode launch config for debugging Mocha tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    // Mocha configs from https://medium.com/guidesmiths-dev/how-to-configure-visual-studio-code-for-test-debugging-39d0d7f24d79
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All within 'test' folder",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${workspaceFolder}/test/**/*"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "envFile": "${workspaceFolder}/.env",
+      "env": { "NODE_ENV": "test" }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": ["--timeout", "999999", "--colors", "${file}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "envFile": "${workspaceFolder}/.env",
+      "env": { "NODE_ENV": "test" }
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Added
 
 - Storing and checking for door heartbeat messages (CU-wf97dy).
+- Mocha debugging configuration.
 
 ### Changed
 


### PR DESCRIPTION
- So that those of us who use VS Code will be able to use it to
  debug Mocha tests without any extra work

@mariocimet , after our code review / pair programming session last week, I started thinking that we _shoud_ be able to have a debugger working in VS code. And it didn't actually take much effort to make this work. Wish I'd done it much earlier. 

This adds two run configurations. One which runs all the tests in the `/test` folder and the other which runs all the tests in the currently-open file.

All you need to do is open up the "Run and Debug" View, by clicking on the 
![image](https://user-images.githubusercontent.com/1490437/121962364-825fe380-cd1d-11eb-8b57-e51b8d08b530.png)
icon in the left menu, then you can select which of those Run configurations you want to use in this dropdown menu:
![image](https://user-images.githubusercontent.com/1490437/121962452-999ed100-cd1d-11eb-9066-9801fb0303bf.png)
and push the "Play" button.

Then, it will run the tests and stop at any breakpoints that you've set in the code and then you can explore the current value of all the in-scope variables, you can create Watch expressions, and explore the call stack:
![image](https://user-images.githubusercontent.com/1490437/121962692-ef737900-cd1d-11eb-9fc0-28e056e9f232.png)

Honestly, why didn't I do this earlier??????