### PR TITLE
Add audit-ci to Travis to perform static security checks (CU-121j22d)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,10 @@ before_script:
 
 jobs:
   include:
-    # Run linting, unit tests, and integration tests
+    # Run security audit, linting, unit tests, and integration tests
     - stage: test
       script:
+        - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
         - npm run lint
         - sudo env "PATH=$PATH" npm test
     # If all the test stage passes, then pushes the Docker container to DO

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ the code was deployed.
 
 - Endpoint for firmware state machine alerts (CU-v9ae26).
 - Storing and checking firmware state machine heartbeat messages (CU-v9ae26).
+- Security audit to Travis (CU-121j22d).
 
 ### Changed
 
 - Decoupled state machine from Sessions (CU-v9ae26).
 - Refactored and merged radar state machines (CU-v9ae26).
-
 
 ## [3.4.0] - 2021-06-21
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,0 +1,4 @@
+{
+  "high": true,
+  "allowlist": []
+}


### PR DESCRIPTION
- This will block the build when there are high or critical security
  issues. The build will only pass if these issues are added to the
  allowlist in audit-ci.json or fixed.

## Test Plan:
- :heavy_check_mark: With no changes in the project
   - :heavy_check_mark: See in the Travis logs that it ran (https://app.travis-ci.com/github/bravetechnologycoop/BraveSensor-Server/jobs/525028217)
   - :heavy_check_mark: Travis passes
- :heavy_check_mark: Add a known low severity security issue to the project
   - :heavy_check_mark: See in the Travis logs that it ran (https://app.travis-ci.com/github/bravetechnologycoop/BraveSensor-Server/jobs/525028875)
   - :heavy_check_mark: Travis passes
- :heavy_check_mark: Add a known high severity security issue to the project 
   - :heavy_check_mark: See in the Travis logs that it ran (https://app.travis-ci.com/github/bravetechnologycoop/BraveSensor-Server/jobs/525035512)
   - :heavy_check_mark: Travis fails