### PR TITLE
Add GET /alert/historicAlerts endpoint and `sessions.responded_at` column (CU-hjwfx2)

### DIFF
--- a/AlertReasonEnum.js
+++ b/AlertReasonEnum.js
@@ -1,7 +1,0 @@
-const ALERT_REASON = {
-  DURATION: 'Duration',
-  STILLNESS: 'Stillness',
-  NOTSET: 'NotSet',
-}
-
-module.exports = Object.freeze(ALERT_REASON)

--- a/BraveAlerterConfigurator.js
+++ b/BraveAlerterConfigurator.js
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
 // In-house dependencies
-const { BraveAlerter, AlertSession, ALERT_STATE, helpers, Location, SYSTEM } = require('brave-alert-lib')
+const { BraveAlerter, AlertSession, CHATBOT_STATE, helpers, Location, SYSTEM } = require('brave-alert-lib')
 const db = require('./db/db')
 
 const incidentTypes = ['No One Inside', 'Person responded', 'Overdose', 'None of the above']
@@ -14,6 +14,8 @@ class BraveAlerterConfigurator {
       this.getAlertSessionByPhoneNumber.bind(this),
       this.alertSessionChangedCallback.bind(this),
       this.getLocationByAlertApiKey.bind(this),
+      this.getHistoricAlertsByAlertApiKey.bind(this),
+      () => {},
       false,
       this.getReturnMessage.bind(this),
     )
@@ -96,26 +98,30 @@ class BraveAlerterConfigurator {
     return new Location(locations[0].locationid, SYSTEM.SENSOR)
   }
 
+  async getHistoricAlertsByAlertApiKey() {
+    return null
+  }
+
   getReturnMessage(fromAlertState, toAlertState) {
     let returnMessage
 
     switch (fromAlertState) {
-      case ALERT_STATE.STARTED:
-      case ALERT_STATE.WAITING_FOR_REPLY:
+      case CHATBOT_STATE.STARTED:
+      case CHATBOT_STATE.WAITING_FOR_REPLY:
         returnMessage =
           'Please respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above'
         break
 
-      case ALERT_STATE.WAITING_FOR_CATEGORY:
-        if (toAlertState === ALERT_STATE.WAITING_FOR_CATEGORY) {
+      case CHATBOT_STATE.WAITING_FOR_CATEGORY:
+        if (toAlertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
           returnMessage =
             'Invalid category, please try again\n\nPlease respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above'
-        } else if (toAlertState === ALERT_STATE.COMPLETED) {
+        } else if (toAlertState === CHATBOT_STATE.COMPLETED) {
           returnMessage = 'Thank you!'
         }
         break
 
-      case ALERT_STATE.COMPLETED:
+      case CHATBOT_STATE.COMPLETED:
         returnMessage = 'Thank you'
         break
 

--- a/BraveAlerterConfigurator.js
+++ b/BraveAlerterConfigurator.js
@@ -68,8 +68,19 @@ class BraveAlerterConfigurator {
       const session = await db.getSessionWithSessionId(alertSession.sessionId, client)
 
       if (session) {
-        const incidentType = incidentTypes[incidentTypeKeys.indexOf(alertSession.incidentCategoryKey)]
-        await db.saveAlertSession(alertSession.alertState, incidentType, alertSession.sessionId, client)
+        if (alertSession.alertState) {
+          session.chatbotState = alertSession.alertState
+        }
+
+        if (alertSession.incidentCategoryKey) {
+          session.incidentType = incidentTypes[incidentTypeKeys.indexOf(alertSession.incidentCategoryKey)]
+        }
+
+        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
+          session.respondedAt = await db.getCurrentTime(client)
+        }
+
+        await db.saveSession(session, client)
       } else {
         helpers.logError(`alertSessionChangedCallback was called for a non-existent session: ${alertSession.sessionId}`)
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the code was deployed.
 
 - Alert Type to the Dashboard.
 - Tracking of when sessions are first responded to (CU-hjwfx2).
+- `GET /alert/historicAlerts` endpoint (CU-hjwfx2).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Added
 
 - Alert Type to the Dashboard.
+- Tracking of when sessions are first responded to (CU-hjwfx2).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Alert Type to the Dashboard.
+
+### Changed
+
+- Use an enum for Alert Type in the DB and from Alert Lib instead of strings.
+
 ## [4.0.0] - 2021-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You will need to populate the .env file with connection parameters for both redi
 To do this, cd into the BraveSensor-Server directory and run the following command
 
 ```
-sudo PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> setup_postgresql_local.sh
+sudo PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> ./setup_postgresql_local.sh
 ```
 
 ## Tests
@@ -274,6 +274,7 @@ This strategy assumes that each migration script in the `db` directory has a u
    FROM migrations
    ORDER BY id;
    ```
+
 # Cluster Migration and Setup
 
 ## Setting up networking for a new cluster

--- a/Session.js
+++ b/Session.js
@@ -1,5 +1,5 @@
 class Session {
-  constructor(id, locationid, phoneNumber, chatbotState, alertType, createdAt, updatedAt, incidentType, notes) {
+  constructor(id, locationid, phoneNumber, chatbotState, alertType, createdAt, updatedAt, incidentType, notes, respondedAt) {
     this.id = id
     this.locationid = locationid
     this.phoneNumber = phoneNumber
@@ -9,6 +9,7 @@ class Session {
     this.updatedAt = updatedAt
     this.incidentType = incidentType
     this.notes = notes
+    this.respondedAt = respondedAt
   }
 }
 

--- a/Session.js
+++ b/Session.js
@@ -1,10 +1,10 @@
 class Session {
-  constructor(id, locationid, phoneNumber, chatbotState, alertReason, createdAt, updatedAt, incidentType, notes) {
+  constructor(id, locationid, phoneNumber, chatbotState, alertType, createdAt, updatedAt, incidentType, notes) {
     this.id = id
     this.locationid = locationid
     this.phoneNumber = phoneNumber
     this.chatbotState = chatbotState
-    this.alertReason = alertReason
+    this.alertType = alertType
     this.createdAt = createdAt
     this.updatedAt = updatedAt
     this.incidentType = incidentType

--- a/db/019-change-alert-reason-values.sql
+++ b/db/019-change-alert-reason-values.sql
@@ -1,0 +1,44 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 19;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        -- Note: To view enum types and their values in `psql`, use the command `\dT+`
+        CREATE TYPE alert_type_enum AS ENUM ('BUTTONS_NOT_URGENT', 'BUTTONS_URGENT', 'SENSOR_STILLNESS', 'SENSOR_DURATION', 'SENSOR_UNKNOWN');
+
+        ALTER TABLE sessions
+        ADD COLUMN alert_type alert_type_enum;
+
+        UPDATE sessions
+        SET alert_type = 'SENSOR_STILLNESS'
+        WHERE alert_reason = 'Stillness';
+
+        UPDATE sessions
+        SET alert_type = 'SENSOR_DURATION'
+        WHERE alert_reason = 'Duration';
+
+        UPDATE sessions
+        SET alert_type = 'SENSOR_UNKNOWN'
+        WHERE alert_reason = 'Unknown';
+
+        ALTER TABLE sessions
+        DROP COLUMN alert_reason;
+
+        ALTER TABLE sessions
+        ALTER COLUMN alert_type
+        SET NOT NULL;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/db/020-add-responded-at-to-sessions.sql
+++ b/db/020-add-responded-at-to-sessions.sql
@@ -1,0 +1,22 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 20;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE sessions 
+        ADD COLUMN responded_at timestamptz;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/db/db.js
+++ b/db/db.js
@@ -2,7 +2,7 @@
 const pg = require('pg')
 
 // In-house dependencies
-const { ALERT_STATE, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, helpers } = require('brave-alert-lib')
 const Session = require('../Session')
 const Location = require('../Location')
 
@@ -25,7 +25,7 @@ pool.on('error', err => {
 
 function createSessionFromRow(r) {
   // prettier-ignore
-  return new Session(r.id, r.locationid, r.phone_number, r.chatbot_state, r.alert_reason, r.created_at, r.updated_at, r.incident_type, r.notes)
+  return new Session(r.id, r.locationid, r.phone_number, r.chatbot_state, r.alert_type, r.created_at, r.updated_at, r.incident_type, r.notes)
 }
 
 function createLocationFromRow(r) {
@@ -171,7 +171,7 @@ async function getUnrespondedSessionWithLocationId(locationid, clientParam) {
     const results = await runQuery(
       'getUnrespondedSessionWithLocationId',
       'SELECT * FROM sessions WHERE locationid = $1 AND chatbot_state != $2 AND chatbot_state != $3 AND chatbot_state != $4 ORDER BY created_at DESC LIMIT 1',
-      [locationid, ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_DETAILS, ALERT_STATE.COMPLETED],
+      [locationid, CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_DETAILS, CHATBOT_STATE.COMPLETED],
       clientParam,
     )
 
@@ -205,12 +205,12 @@ async function getAllSessionsFromLocation(locationid, clientParam) {
 }
 
 // Creates a new session for a specific location
-async function createSession(locationid, phoneNumber, alertReason, clientParam) {
+async function createSession(locationid, phoneNumber, alertType, clientParam) {
   try {
     const results = await runQuery(
       'createSession',
-      'INSERT INTO sessions(locationid, phone_number, alert_reason, chatbot_state) VALUES ($1, $2, $3, $4) RETURNING *',
-      [locationid, phoneNumber, alertReason, ALERT_STATE.STARTED],
+      'INSERT INTO sessions(locationid, phone_number, alert_type, chatbot_state) VALUES ($1, $2, $3, $4) RETURNING *',
+      [locationid, phoneNumber, alertType, CHATBOT_STATE.STARTED],
       clientParam,
     )
     return createSessionFromRow(results.rows[0])

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ async function handleAlert(location, alertType) {
       braveAlerter.startAlertSession(alertInfo)
     } else if (currentTime - currentSession.updatedAt >= helpers.getEnvVar('SUBSEQUENT_ALERT_MESSAGE_THRESHOLD')) {
       helpers.log('handleAlert: sending singleAlert')
-      await db.updateSession(currentSession.id, client)
+      await db.saveSession(currentSession, client)
       braveAlerter.sendSingleAlert(
         location.responderPhoneNumber,
         location.twilioNumber,
@@ -380,6 +380,7 @@ app.get('/locations/:locationId', sessionChecker, async (req, res) => {
         id: recentSession.id,
         chatbotState: recentSession.chatbotState,
         alertType: getAlertTypeDisplayName(recentSession.alertType),
+        respondedAt: recentSession.respondedAt,
       })
     }
 

--- a/mustache-templates/locationsDashboard.mst
+++ b/mustache-templates/locationsDashboard.mst
@@ -31,6 +31,7 @@
                             <th scope="col">Updated At</th>
                             <th scope="col">Chatbot State</th>
                             <th scope="col">Incident Type</th>
+                            <th scope="col">Alert Type</th>
                             <th scope="col">Notes</th>
                         </tr>
                     </thead>
@@ -42,6 +43,7 @@
                                 <td>{{updatedAt}}</td>
                                 <td>{{chatbotState}}</td>
                                 <td>{{incidentType}}</td>
+                                <td>{{alertType}}</td>
                                 <td>{{notes}}</td>
                             </tr>
                         {{/recentSessions}}

--- a/mustache-templates/locationsDashboard.mst
+++ b/mustache-templates/locationsDashboard.mst
@@ -29,6 +29,7 @@
                             <th scope="col">Session ID</th>
                             <th scope="col">Created At</th>
                             <th scope="col">Updated At</th>
+                            <th scope="col">Responded At</th>
                             <th scope="col">Chatbot State</th>
                             <th scope="col">Incident Type</th>
                             <th scope="col">Alert Type</th>
@@ -41,6 +42,7 @@
                                 <th scope="row">{{id}}</th>
                                 <td>{{createdAt}}</td>
                                 <td>{{updatedAt}}</td>
+                                <td>{{respondedAt}}</td>
                                 <td>{{chatbotState}}</td>
                                 <td>{{incidentType}}</td>
                                 <td>{{alertType}}</td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -672,8 +672,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#66cb40c57968ffbc69dda09a1b709c8a40619069",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v3.3.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#5d22132bb4510841553fa50cf0863f7bc98a3c5a",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v4.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -1000,9 +1000,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
-      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "debug": {
       "version": "4.3.1",
@@ -4038,15 +4038,15 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.63.1",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.63.1.tgz",
-      "integrity": "sha512-xwtOM78sO2jGxKg1AW+7XlJdrhTMW9dzr6665O+IB/VtNVQB7JQS48pLCZFnBaTvZOILVO0Q6t63wv24hIbr/A==",
+      "version": "3.66.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.66.1.tgz",
+      "integrity": "sha512-BmIgfx2VuS7tj4IscBhyEj7CdmtfIaaJ1IuNeGoJFYBx5xikpuwkR0Ceo5CNtK5jnN3SCKmxHxToec/MYEXl0A==",
       "requires": {
         "axios": "^0.21.1",
         "dayjs": "^1.8.29",
         "https-proxy-agent": "^5.0.0",
         "jsonwebtoken": "^8.5.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.21",
         "q": "2.0.x",
         "qs": "^6.9.4",
         "rootpath": "^0.1.2",
@@ -4135,9 +4135,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "requires": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v3.3.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v4.0.0",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/setup_postgresql.sh
+++ b/setup_postgresql.sh
@@ -18,3 +18,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/017-add-is-active-to-locations.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/018-refactor-sessions.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/019-change-alert-reason-values.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/020-add-responded-at-to-sessions.sql

--- a/setup_postgresql.sh
+++ b/setup_postgresql.sh
@@ -17,3 +17,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/016-alterheatbeackphonenumbertobeanarray.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/017-add-is-active-to-locations.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/018-refactor-sessions.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/019-change-alert-reason-values.sql

--- a/stateMachine/StateMachine.js
+++ b/stateMachine/StateMachine.js
@@ -1,7 +1,6 @@
-const { helpers } = require('brave-alert-lib')
+const { ALERT_TYPE, helpers } = require('brave-alert-lib')
 const stateMachineHelpers = require('./stateMachineHelpers')
 const redis = require('../db/redis')
-const ALERT_REASON = require('../AlertReasonEnum')
 const DOOR_STATUS = require('../SessionStateDoorEnum')
 const STATE = require('./SessionStateEnum')
 
@@ -47,7 +46,7 @@ async function getNextState(location, handleAlert) {
             STATE.INITIAL_TIMER,
           )
         ) {
-          await handleAlert(location, ALERT_REASON.DURATION)
+          await handleAlert(location, ALERT_TYPE.SENSOR_DURATION)
           await redis.addStateMachineData(STATE.IDLE, location.locationid)
         }
         break
@@ -57,7 +56,7 @@ async function getNextState(location, handleAlert) {
         } else if (movementOverThreshold) {
           await redis.addStateMachineData(STATE.DURATION_TIMER, location.locationid)
         } else if (await stateMachineHelpers.timerExceeded(location.locationid, parseInt(location.stillnessTimer, 10), STATE.STILLNESS_TIMER)) {
-          await handleAlert(location, ALERT_REASON.STILLNESS)
+          await handleAlert(location, ALERT_TYPE.SENSOR_STILLNESS)
           await redis.addStateMachineData(STATE.IDLE, location.locationid)
         } else if (
           await stateMachineHelpers.timerExceeded(
@@ -66,7 +65,7 @@ async function getNextState(location, handleAlert) {
             STATE.INITIAL_TIMER,
           )
         ) {
-          await handleAlert(location, ALERT_REASON.DURATION)
+          await handleAlert(location, ALERT_TYPE.SENSOR_DURATION)
           await redis.addStateMachineData(STATE.IDLE, location.locationid)
         }
         break

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -42,10 +42,10 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     const locationId = (await db.getLocations())[0].locationid
 
     // Insert a session for that location in the DB
-    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
-    const id = (await db.getAllSessionsFromLocation(locationId))[0].id
-    await db.saveAlertSession(this.expectedChatbotState, this.expectedIncidentType, id)
-    this.session = await db.getSessionWithSessionId(id)
+    this.session = await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
+    this.session.chatbotState = this.expectedChatbotState
+    this.session.incidentType = this.expectedIncidentType
+    await db.saveSession(this.session)
   })
 
   afterEach(async () => {

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -3,8 +3,7 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE, AlertSession } = require('brave-alert-lib')
-const ALERT_REASON = require('../../../AlertReasonEnum')
+const { CHATBOT_STATE, ALERT_TYPE, AlertSession } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
 
@@ -13,7 +12,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     await db.clearSessions()
     await db.clearLocations()
 
-    this.expectedChatbotState = ALERT_STATE.WAITING_FOR_CATEGORY
+    this.expectedChatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
     this.expectedIncidentType = 'No One Inside'
     this.expectedLocationDisplayName = 'TEST LOCATION'
     this.expectedLocationPhoneNumber = '+17772225555'
@@ -43,7 +42,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     const locationId = (await db.getLocations())[0].locationid
 
     // Insert a session for that location in the DB
-    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_REASON.DURATION)
+    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
     const id = (await db.getAllSessionsFromLocation(locationId))[0].id
     await db.saveAlertSession(this.expectedChatbotState, this.expectedIncidentType, id)
     this.session = await db.getSessionWithSessionId(id)

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -41,10 +41,10 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     const locationId = (await db.getLocations())[0].locationid
 
     // Insert a session for that location in the DB
-    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
-    const sessionid = (await db.getAllSessionsFromLocation(locationId))[0].id
-    await db.saveAlertSession(this.expectedChatbotState, this.expectedIncidentType, sessionid)
-    this.session = await db.getSessionWithSessionId(sessionid)
+    this.session = await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
+    this.session.chatbotState = this.expectedChatbotState
+    this.session.incidentType = this.expectedIncidentType
+    db.saveSession(this.session)
   })
 
   afterEach(async () => {

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -3,8 +3,7 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE, AlertSession } = require('brave-alert-lib')
-const ALERT_REASON = require('../../../AlertReasonEnum')
+const { CHATBOT_STATE, ALERT_TYPE, AlertSession } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
 
@@ -13,7 +12,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     await db.clearSessions()
     await db.clearLocations()
 
-    this.expectedChatbotState = ALERT_STATE.WAITING_FOR_CATEGORY
+    this.expectedChatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
     this.expectedIncidentType = 'No One Inside'
     this.expectedLocationDisplayName = 'TEST LOCATION'
     this.expectedLocationPhoneNumber = '+17772225555'
@@ -42,7 +41,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     const locationId = (await db.getLocations())[0].locationid
 
     // Insert a session for that location in the DB
-    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_REASON.DURATION)
+    await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
     const sessionid = (await db.getAllSessionsFromLocation(locationId))[0].id
     await db.saveAlertSession(this.expectedChatbotState, this.expectedIncidentType, sessionid)
     this.session = await db.getSessionWithSessionId(sessionid)

--- a/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -1,0 +1,395 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const { ALERT_TYPE, CHATBOT_STATE, helpers } = require('brave-alert-lib')
+
+// In-house dependencies
+const db = require('../../../db/db')
+const Session = require('../../../Session')
+const RADAR_TYPE = require('../../../RadarTypeEnum')
+
+describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
+  describe('if there are no locations with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createLocation(
+        'locationid',
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        RADAR_TYPE.INNOSENT,
+        'alertApiKey',
+        true,
+        false,
+      )
+      const locationid = (await db.getLocations())[0].locationid
+      const session = await db.createSession(locationid, 'phoneNumber', ALERT_TYPE.SENSOR_DURATION)
+      session.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(session)
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey('not alertApiKey', 10, 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there are no sessions for the installation with the given Alert API Key', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location that has a single session that doesn't match the Alert API Key that we ask for
+      await db.createLocation(
+        'locationid',
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        RADAR_TYPE.INNOSENT,
+        'not our API key',
+        true,
+        false,
+      )
+      const locationid = (await db.getLocations())[0].locationid
+      const session = await db.createSession(locationid, 'phoneNumber', ALERT_TYPE.SENSOR_DURATION)
+      session.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(session)
+
+      // Insert a single location with no sessions that matches the Alert API Key that we ask for
+      this.alertApiKey = 'alertApiKey'
+      await db.createLocation(
+        'locationid2',
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        RADAR_TYPE.INNOSENT,
+        this.alertApiKey,
+        true,
+        false,
+      )
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+    })
+
+    it('should return an empty array', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 10, 50000)
+
+      expect(rows).to.eql([])
+    })
+  })
+
+  describe('if there is one matching session', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location
+      this.alertApiKey = 'alertApiKey'
+      this.displayName = 'displayName'
+      const locationid = 'locationid'
+      const phonenumber = 'phonenumber'
+      await db.createLocation(
+        locationid,
+        phonenumber,
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        this.displayName,
+        'doorCoreId',
+        'radarCoreId',
+        RADAR_TYPE.INNOSENT,
+        this.alertApiKey,
+        true,
+        false,
+      )
+
+      // Insert a single session for that API key
+      this.incidentType = ALERT_TYPE.SENSOR_DURATION
+      this.respondedAt = new Date('2021-01-20T06:20:19.000Z')
+      this.alertType = ALERT_TYPE.SENSOR_DURATION
+      this.session = await db.createSession(locationid, phonenumber, this.alertType)
+      await db.saveSession(
+        new Session(
+          this.session.id,
+          this.session.locationid,
+          this.session.phoneNumber,
+          this.session.chatbotState,
+          this.session.alertType,
+          this.session.createdAt,
+          this.session.updatedAt,
+          this.incidentType,
+          this.session.notes,
+          this.respondedAt,
+        ),
+      )
+    })
+
+    afterEach(async () => {
+      await db.clearLocations()
+    })
+
+    it('should return an array with one object with the correct values in it', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 1)
+
+      expect(rows).to.eql([
+        {
+          id: this.session.id,
+          display_name: this.displayName,
+          incident_type: this.incidentType,
+          alert_type: this.alertType,
+          created_at: this.session.createdAt,
+          responded_at: this.respondedAt,
+        },
+      ])
+    })
+  })
+
+  describe('if there are more matching sessions than maxHistoricAlerts', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location and more than maxHistoricAlerts sessions
+      this.alertApiKey = 'alertApiKey'
+      const locationid = 'locationid'
+      await db.createLocation(
+        locationid,
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        'radarType',
+        this.alertApiKey,
+        true,
+        false,
+      )
+
+      this.session1 = await db.createSession(locationid, 'phonenumber1', ALERT_TYPE.SENSOR_DURATION)
+      this.session2 = await db.createSession(locationid, 'phonenumber2', ALERT_TYPE.SENSOR_DURATION)
+      this.session3 = await db.createSession(locationid, 'phonenumber3', ALERT_TYPE.SENSOR_DURATION)
+      this.session4 = await db.createSession(locationid, 'phonenumber4', ALERT_TYPE.SENSOR_DURATION)
+      this.session5 = await db.createSession(locationid, 'phonenumber5', ALERT_TYPE.SENSOR_DURATION)
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+    })
+
+    it('should return only the most recent maxHistoricAlerts of them', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 3, 1)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session5.id, this.session4.id, this.session3.id])
+    })
+  })
+
+  describe('if there are fewer matching sessions than maxHistoricAlerts', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location and maxHistoricAlerts sessions
+      this.alertApiKey = 'alertApiKey'
+      const locationid = 'locationid'
+      await db.createLocation(
+        locationid,
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        'radarType',
+        this.alertApiKey,
+        true,
+        false,
+      )
+
+      this.maxTimeAgoInMillis = 1000
+
+      // Incompleted sessions older than `this.maxTimeAgoInMillis` should be returned
+      this.session1 = await db.createSession(locationid, 'phonenumber1', ALERT_TYPE.SENSOR_DURATION)
+      this.session2 = await db.createSession(locationid, 'phonenumber2', ALERT_TYPE.SENSOR_DURATION)
+
+      await helpers.sleep(this.maxTimeAgoInMillis)
+
+      // Inncompleted sessions more recent than `this.maxTimeAgoInMillis` should not be returned
+      this.session3 = await db.createSession(locationid, 'phonenumber3', ALERT_TYPE.SENSOR_DURATION)
+      this.session4 = await db.createSession(locationid, 'phonenumber4', ALERT_TYPE.SENSOR_DURATION)
+      this.session5 = await db.createSession(locationid, 'phonenumber5', ALERT_TYPE.SENSOR_DURATION)
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+    })
+
+    it('should return only the matches', async () => {
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 5, this.maxTimeAgoInMillis)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session2.id, this.session1.id])
+    })
+  })
+
+  describe('if is a session more recent than maxTimeAgoInMillis', () => {
+    beforeEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+
+      // Insert a single location and one session
+      this.alertApiKey = 'alertApiKey'
+      const locationid = 'locationid'
+      await db.createLocation(
+        locationid,
+        'phonenumber',
+        'movementThreshold',
+        'stillnessThreshold',
+        'durationTimer',
+        120000,
+        'initialTimer',
+        '{"heartbeatAlertRecipients"}',
+        'twilioNumber',
+        '{"fallbackNumbers"}',
+        300000,
+        'displayName',
+        'doorCoreId',
+        'radarCoreId',
+        'radarType',
+        this.alertApiKey,
+        true,
+        false,
+      )
+
+      this.session = await db.createSession(locationid, 'phonenumber1', ALERT_TYPE.SENSOR_DURATION)
+    })
+
+    afterEach(async () => {
+      await db.clearSessions()
+      await db.clearLocations()
+    })
+
+    it('and it is COMPLETED, should return the Completed session', async () => {
+      // Update the session to COMPLETED
+      const updatedSession = { ...this.session }
+      updatedSession.chatbotState = CHATBOT_STATE.COMPLETED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([this.session.id])
+    })
+
+    it('and it is WAITING_FOR_CATEGORY, should not return it', async () => {
+      // Update the session to WAITING_FOR_CATEGORY
+      const updatedSession = { ...this.session }
+      updatedSession.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is WAITING_FOR_REPLY, should not return it', async () => {
+      // Update the session to WAITING_FOR_REPLY
+      const updatedSession = { ...this.session }
+      updatedSession.chatbotState = CHATBOT_STATE.WAITING_FOR_REPLY
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+
+    it('and it is STARTED, should not return it', async () => {
+      // Update the session to STARTED
+      const updatedSession = { ...this.session }
+      updatedSession.chatbotState = CHATBOT_STATE.STARTED
+      await db.saveSession(updatedSession)
+
+      // maxTimeAgoInMillis is much greater than the time this test should take to run
+      const rows = await db.getHistoricAlertsByAlertApiKey(this.alertApiKey, 1, 120000)
+
+      const ids = rows.map(row => row.id)
+
+      expect(ids).to.eql([])
+    })
+  })
+})

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -6,7 +6,7 @@ const chaiDateTime = require('chai-datetime')
 const expect = chai.expect
 const { after, afterEach, before, beforeEach, describe, it } = require('mocha')
 const sinon = require('sinon')
-const { helpers } = require('brave-alert-lib')
+const { ALERT_TYPE, helpers } = require('brave-alert-lib')
 const { sleep } = require('brave-alert-lib/lib/helpers')
 const imports = require('../../index')
 
@@ -16,7 +16,6 @@ const server = imports.server
 const braveAlerter = imports.braveAlerter
 const StateMachine = require('../../stateMachine/StateMachine')
 const XETHRU_STATE = require('../../SessionStateXethruEnum')
-const ALERT_REASON = require('../../AlertReasonEnum')
 const SENSOR_EVENT = require('../../SensorEventEnum')
 
 const MOVEMENT_THRESHOLD = 40
@@ -202,7 +201,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.DURATION)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_DURATION)
     })
 
     it('should create a session with STILLNESS as the alert reason for a valid STILLNESS request', async () => {
@@ -210,7 +209,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.STILLNESS)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)
     })
 
     it('should only create one new session when receiving multiple alerts within the session reset timeout', async () => {
@@ -221,7 +220,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.STILLNESS)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)
     })
 
     it('should update updatedAt for the session when a new alert is received within the session reset timeout', async () => {
@@ -229,7 +228,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const oldUpdatedAt = sessions[0].updatedAt
       await sleep(1000)
-      await firmwareAlert(radar_coreID, ALERT_REASON.STILLNESS)
+      await firmwareAlert(radar_coreID, ALERT_TYPE.SENSOR_STILLNESS)
       const newSessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const newUpdatedAt = newSessions[0].updatedAt
       expect(newUpdatedAt).to.be.afterTime(oldUpdatedAt)
@@ -243,7 +242,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(2)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.DURATION)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_DURATION)
     })
   })
 
@@ -348,7 +347,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.STILLNESS)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)
     })
 
     it('radar data showing movement should start a Duration timer, if movement persists without a door opening for longer than the duration threshold, it should trigger an alert', async () => {
@@ -360,7 +359,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.DURATION)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_DURATION)
     })
   })
 
@@ -543,7 +542,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.STILLNESS)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)
     })
 
     it('radar data showing movement should trigger a session, if movement persists without a door opening for longer than the duration threshold, it should trigger an alert', async () => {
@@ -555,7 +554,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(1)
       const session = sessions[0]
-      expect(session.alertReason).to.equal(ALERT_REASON.DURATION)
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_DURATION)
     })
   })
 

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -228,7 +228,7 @@ describe('Brave Sensor server', () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const oldUpdatedAt = sessions[0].updatedAt
       await sleep(1000)
-      await firmwareAlert(radar_coreID, ALERT_TYPE.SENSOR_STILLNESS)
+      await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
       const newSessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const newUpdatedAt = newSessions[0].updatedAt
       expect(newUpdatedAt).to.be.afterTime(oldUpdatedAt)

--- a/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 
 // In-house dependencies
-const { ALERT_STATE, AlertSession, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, AlertSession, helpers } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
 const redis = require('../../../db/redis')
@@ -45,11 +45,11 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     beforeEach(async () => {
       const braveAlerterConfigurator = new BraveAlerterConfigurator()
       const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, ALERT_STATE.WAITING_FOR_REPLY))
+      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, CHATBOT_STATE.WAITING_FOR_REPLY))
     })
 
     it('should update the chatbotState', () => {
-      expect(db.saveAlertSession).to.be.calledWith(ALERT_STATE.WAITING_FOR_REPLY, undefined, this.testSessionId)
+      expect(db.saveAlertSession).to.be.calledWith(CHATBOT_STATE.WAITING_FOR_REPLY, undefined, this.testSessionId)
     })
   })
 
@@ -71,11 +71,11 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     beforeEach(async () => {
       const braveAlerterConfigurator = new BraveAlerterConfigurator()
       const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, ALERT_STATE.COMPLETED, '2'))
+      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, CHATBOT_STATE.COMPLETED, '2'))
     })
 
     it('should update chatbotState and incidentType', () => {
-      expect(db.saveAlertSession).to.be.calledWith(ALERT_STATE.COMPLETED, 'Person responded', this.testSessionId, this.testClient)
+      expect(db.saveAlertSession).to.be.calledWith(CHATBOT_STATE.COMPLETED, 'Person responded', this.testSessionId, this.testClient)
     })
   })
 })

--- a/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/test/unit/BraveAlerterConfiguratorTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -1,0 +1,116 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { helpers, HistoricAlert, ALERT_TYPE } = require('brave-alert-lib')
+const db = require('../../../db/db')
+const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+
+// Configure Chai
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+describe('BraveAlerterConfigurator.js unit tests: getHistoricAlertsByAlertApiKey and createHistoricAlertFromRow', () => {
+  beforeEach(() => {
+    this.maxTimeAgoInMillis = 60000
+    sandbox.stub(helpers, 'getEnvVar').withArgs('SESSION_RESET_THRESHOLD').returns(this.maxTimeAgoInMillis)
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    this.braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('if there is a single result from db.getHistoricAlertsByAlertApiKey, returns an array containing a single HistoricAlert object with the returned data', async () => {
+    const results = {
+      id: 'id',
+      display_name: 'displayName',
+      incident_type: 'incidentType',
+      alert_type: ALERT_TYPE.SENSOR_DURATION,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+      responded_at: new Date('2020-01-20T10:12:40.000Z'),
+    }
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([
+      new HistoricAlert(results.id, results.display_name, results.incident_type, results.alert_type, null, results.created_at, results.responded_at),
+    ])
+  })
+
+  it('if there are multiple results from db.getHistoricAlertsByAlertApiKey, returns an array containing the HistoricAlert objects with the returned data', async () => {
+    const results1 = {
+      id: 'id1',
+      display_name: 'displayName1',
+      incident_type: 'incidentType1',
+      alert_type: ALERT_TYPE.SENSOR_DURATION,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+      responded_at: new Date('2020-01-20T10:12:40.000Z'),
+    }
+    const results2 = {
+      id: 'id2',
+      display_name: 'displayName2',
+      incident_type: 'incidentType2',
+      alert_type: ALERT_TYPE.SENSOR_NO_MOTION,
+      created_at: new Date('2019-02-20T09:10:10.000Z'),
+      responded_at: new Date('2019-02-20T09:12:40.000Z'),
+    }
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([results1, results2])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([
+      new HistoricAlert(
+        results1.id,
+        results1.display_name,
+        results1.incident_type,
+        results1.alert_type,
+        null,
+        results1.created_at,
+        results1.responded_at,
+      ),
+      new HistoricAlert(
+        results2.id,
+        results2.display_name,
+        results2.incident_type,
+        results2.alert_type,
+        null,
+        results2.created_at,
+        results2.responded_at,
+      ),
+    ])
+  })
+
+  it('if there no results from db.getHistoricAlertsByAlertApiKey, returns an empty array', async () => {
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns([])
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.eql([])
+  })
+
+  it('if db.getHistoricAlertsByAlertApiKey returns a non-array, returns null', async () => {
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+
+    const historicAlerts = await this.braveAlerter.getHistoricAlertsByAlertApiKey('alertApiKey', 'maxHistoricAlerts')
+
+    expect(historicAlerts).to.be.null
+  })
+
+  it('db.getHistoricAlertsByAlertApiKey is called with the given alertApiKey, the given maxHistoricAlerts, and the SESSION_RESET_THRESHOLD from .env', async () => {
+    sandbox.stub(db, 'getHistoricAlertsByAlertApiKey').returns()
+
+    const alertApiKey = 'alertApiKey'
+    const maxHistoricAlerts = 'maxHistoricAlerts'
+    await this.braveAlerter.getHistoricAlertsByAlertApiKey(alertApiKey, maxHistoricAlerts)
+
+    expect(db.getHistoricAlertsByAlertApiKey).to.be.calledWith(alertApiKey, maxHistoricAlerts, this.maxTimeAgoInMillis)
+  })
+})

--- a/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
+++ b/test/unit/BraveAlerterConfiguratorTest/getReturnMessageTest.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const { before, describe, it } = require('mocha')
 
 // In-house dependencies
-const { ALERT_STATE } = require('brave-alert-lib')
+const { CHATBOT_STATE } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 
 describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
@@ -14,7 +14,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when STARTED => WAITING_FOR_REPLY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.STARTED, ALERT_STATE.WAITING_FOR_REPLY)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_REPLY)
 
     expect(returnMessage).to.equal(
       'Please respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above',
@@ -22,7 +22,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when STARTED => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.STARTED, ALERT_STATE.WAITING_FOR_CATEGORY)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.STARTED, CHATBOT_STATE.WAITING_FOR_CATEGORY)
 
     expect(returnMessage).to.equal(
       'Please respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above',
@@ -30,7 +30,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when WAITING_FOR_REPLY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_REPLY, ALERT_STATE.WAITING_FOR_CATEGORY)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_REPLY, CHATBOT_STATE.WAITING_FOR_CATEGORY)
 
     expect(returnMessage).to.equal(
       'Please respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above',
@@ -38,7 +38,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_CATEGORY', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.WAITING_FOR_CATEGORY)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.WAITING_FOR_CATEGORY)
 
     expect(returnMessage).to.equal(
       'Invalid category, please try again\n\nPlease respond with the number corresponding to the incident. \n1: No One Inside\n2: Person Responded\n3: Overdose\n4: None of the Above',
@@ -46,19 +46,19 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessage', () => {
   })
 
   it('should get message when WAITING_FOR_CATEGORY => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.WAITING_FOR_CATEGORY, ALERT_STATE.COMPLETED)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.WAITING_FOR_CATEGORY, CHATBOT_STATE.COMPLETED)
 
     expect(returnMessage).to.equal('Thank you!')
   })
 
   it('should get message when COMPLETED => COMPLETED', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage(ALERT_STATE.COMPLETED, ALERT_STATE.COMPLETED)
+    const returnMessage = this.alertStateMachine.getReturnMessage(CHATBOT_STATE.COMPLETED, CHATBOT_STATE.COMPLETED)
 
     expect(returnMessage).to.equal('Thank you')
   })
 
   it('should get default message if given something funky', () => {
-    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', ALERT_STATE.COMPLETED)
+    const returnMessage = this.alertStateMachine.getReturnMessage('something funky', CHATBOT_STATE.COMPLETED)
 
     expect(returnMessage).to.equal('Error: No active chatbot found')
   })

--- a/test/unit/StateMachineTest.js
+++ b/test/unit/StateMachineTest.js
@@ -1,17 +1,19 @@
+// Third-party dependencies
 const { expect, use } = require('chai')
 const { describe, it } = require('mocha')
 const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { ALERT_TYPE } = require('brave-alert-lib')
 const redis = require('../../db/redis')
-
-const testLocationId = 'TestLocation1'
-
-const ALERT_REASON = require('../../AlertReasonEnum')
 const STATE = require('../../stateMachine/SessionStateEnum')
 const DOOR_STATE = require('../../SessionStateDoorEnum')
 const StateMachine = require('../../stateMachine/StateMachine')
 const stateMachineHelpers = require('../../stateMachine/stateMachineHelpers')
 const Location = require('../../Location')
+
+const testLocationId = 'TestLocation1'
 
 // Configure Chai
 use(sinonChai)
@@ -391,7 +393,7 @@ describe('StateMachine.js unit tests: getNextState', () => {
       it('should issue a duration alert', async () => {
         const handleAlert = sinon.stub()
         await StateMachine.getNextState(new Location(testLocationId), handleAlert)
-        expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_REASON.DURATION)
+        expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_TYPE.SENSOR_DURATION)
       })
     })
   })
@@ -524,7 +526,7 @@ describe('StateMachine.js unit tests: getNextState', () => {
     it('should issue a duration alert', async () => {
       const handleAlert = sinon.stub()
       await StateMachine.getNextState(new Location(testLocationId), handleAlert)
-      expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_REASON.DURATION)
+      expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_TYPE.SENSOR_DURATION)
     })
   })
 
@@ -554,7 +556,7 @@ describe('StateMachine.js unit tests: getNextState', () => {
     it('should issue a stillness alert', async () => {
       const handleAlert = sinon.stub()
       await StateMachine.getNextState(new Location(testLocationId), handleAlert)
-      expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_REASON.STILLNESS)
+      expect(handleAlert).to.be.calledWith(new Location(testLocationId), ALERT_TYPE.SENSOR_STILLNESS)
     })
   })
 })


### PR DESCRIPTION
- Use alert_type_enum in DB and from Alert Lib instead of strings:
   - To better conform with our [desired shared DB schema](https://docs.google.com/document/d/1k-xkWnR7xoWRi6gEiN8p-nda5bhxDvOqNYCtPNi7OwY/edit)
   - So that we don't need to translate between the AlertReasonEnum.js values here and the alertTypeEnum.js values in BraveAlertLib
- Add `responded_at` to Sessions
   - So that we can display it on the Alert App
   - Also changed the `db.js` functions around saving sessions to be more like the way that Buttons does it for more consistency between the two code bases and so that we only need one DB function for saving sessions instead of two.
- Add `GET /alert/historicAlerts` endpoint
   - For use in the Alert App
- Add corresponding tests

## Test Plan
- :heavy_check_mark: Run the smoke tests
- :heavy_check_mark: Deploy to dev and set the same API key for both `Theresa` (XeThru + server state machine) and `Theresa3` (Boron + firmware state machine) locations
- :heavy_check_mark: Create a real Duration Alert in my bathroom
   - :heavy_check_mark: See Alert Reason "Duration" in the dashboard
   - :heavy_check_mark: See Responded At value in the dashboard
- :heavy_check_mark: Create a real Stillness Alert in my bathroom
   - :heavy_check_mark: See Alert Reason "Stillness" in the dashboard
   - :heavy_check_mark: See Responded At value in the dashboard
- :heavy_check_mark; Hit `GET https://dev.sensors.brave.coop/alert/historicAlerts` for my API key and see that
   - :heavy_check_mark: Not-completed alerts in the last `SESSION_RESET_THRESHOLD` seconds are not returned
   - :heavy_check_mark: Completed alerts in the last `SESSION_RESET_THRESHOLD` seconds are returned
   - :heavy_check_mark: All alerts longer ago than `SESSION_RESET_THRESHOLD` are  returned
   - :heavy_check_mark: Different values for `X-API-KEY` (missing, empty string, no matching API key, matching API key)
   - :heavy_check_mark: Different values for `maxHistoricAlerts` (missing, null, empty string, 0, -1, 1, 99999)
   - :heavy_check_mark: HistoricAlerts which are returned have the values I'd expect based on the Sessions they were created from
-  :heavy_check_mark: Hit the `GET https://chatbot-dev.brave.coop/alert/historicAlerts` endpoint from the Alert App and render its results
- :heavy_check_mark: Verify that the `sessions` table is updated correctly
   - :heavy_check_mark: State transitions
   - :heavy_check_mark: Additional alerts