### PR TITLE
Fix IM21 door signal processing (CU-4avrue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 - Alert Type to the Dashboard.
 - Tracking of when sessions are first responded to (CU-hjwfx2).
 - `GET /alert/historicAlerts` endpoint (CU-hjwfx2).
+- Sentry log when the IM21 sends the tamper bit.
 
 ### Changed
 
@@ -30,6 +31,7 @@ the code was deployed.
 ### Fixed
 
 - Database and Redis error output.
+- IM21 door sensor signal processing (CU-4avrue).
 
 ## [4.0.0] - 2021-07-26
 

--- a/IM21DoorStatusEnum.js
+++ b/IM21DoorStatusEnum.js
@@ -1,9 +1,0 @@
-const IM21_DOOR_STATE = {
-  OPEN: '02',
-  CLOSED: '00',
-  HEARTBEAT_OPEN: '0A',
-  HEARTBEAT_CLOSED: '08',
-  LOW_BATT: '04',
-}
-
-module.exports = Object.freeze(IM21_DOOR_STATE)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ## 2. Database changes
 
-If your changes involve changes to the database schema, you'll need to run your database migration script on the appropriate database for your environment. See the [Database Migration section](#database-migration).
+If your changes involve changes to the database schema, you'll need to run your database migration script on the appropriate database for your environment. See the [Database Migration section](#adding-a-new-database-migration-script).
 
 **If the database changes are breaking, think carefully about how to do this. It may be preferable to briefly shut down the server rather than risk undefined behavior from changing the database schema before changing the code that's running**
 
@@ -144,11 +144,11 @@ Alternately, you have the option of installing these dependencies as docker cont
 
 ## Environment Variables
 
-For local development, we use .env files to set environment variables. To set one of these up, fill in the values in the .env.example and change it's name to `.env`.
+For local development, we use .env files to set environment variables. To set one of these up, copy the `.env.example` and rename it to `.env`, and fill in the values as appropriate.
 
 ## Database Setup
 
-You will need to populate the .env file with connection parameters for both redis and Postgresql. If you are using a local database you will also need to setup the database schema.
+You will need to populate the `.env` file with connection parameters for both redis and Postgresql. If you are using a local database you will also need to setup the database schema.
 
 To do this, cd into the BraveSensor-Server directory and run the following command
 
@@ -158,8 +158,7 @@ sudo PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's pa
 
 ## Tests
 
-Unit tests are written using the [Mocha](https://mochajs.org/) JS test framework
-and the [Chai](https://www.chaijs.com/) assertion library.
+Unit tests are written using the [Mocha](https://mochajs.org/) JS test framework, the [Chai](https://www.chaijs.com/) assertion library, and the [Sinon](https://sinonjs.org/) mocking library.
 
 To run the tests locally:
 
@@ -202,7 +201,7 @@ Reference: https://docs.travis-ci.com/user/environment-variables/#encrypting-env
 
 # Sensors Admin Server
 
-The Sensors Admin server is used for both **dev** and **prod**.
+The Sensors Admin server is used for **dev**, **staging**, and **prod**.
 
 To ssh onto the `sensors-admin` server
 
@@ -230,6 +229,7 @@ The PostgreSQL DB connection parameters are required for the application to open
 | Environment | User      | Database Name       |
 | ----------- | --------- | ------------------- |
 | Production  | doadmin   | backend-replacement |
+| Staging     | bravetest | staging             |
 | Development | bravetest | bravetest           |
 
 To access a database shell
@@ -253,14 +253,15 @@ This strategy assumes that each migration script in the `db` directory has a u
 
 1. Copy `db/000-template.sql` and name it with the desired migration ID (padded with zeros) followed by a short description of what it does e.g. `005-newColumn.sql`
 
-2. Update the file with its migration ID and the new migration scripts
+2. Update the file with its migration ID by replacing `ADD MIGRATION ID HERE` and the new migration scripts by adding it to the section `-- ADD SCRIPT HERE`.
+
+3. Update the `setup_postgresql.sh` file to include the newly-created `.sql` file at the bottom
 
 ## Deploying the migration scripts
 
 1. In the BraveSensor-Server directory, run the following command
 
    ```
-
    PG_PORT=<your db's port> PG_HOST=<your db's host> PG_PASSWORD=<your db's password> PG_USER=<your db's user> PG_DATABASE=<your db name> ./setup_postgresql.sh
    ```
 

--- a/im21door.js
+++ b/im21door.js
@@ -1,0 +1,66 @@
+/* eslint-disable no-bitwise */
+// This file relies on the use of bitwise-AND (&)
+
+// Bit mapping from section 5 of https://drive.google.com/drive/folders/1XtnRY1ri_p0hvTmEYqqxfRy2tkf6x0jL
+const IM21_SIGNAL_BIT = {
+  HEARTBEAT: 8, // binary 1000
+  BATTERY: 4, // binary 0100
+  STATE: 2, // binary 0010
+  TAMPERED: 1, // binary 0001
+}
+
+// Expects to be given a hexidecimal string
+// Returns a boolean
+function isLowBattery(signal) {
+  const intSignal = parseInt(signal, 16)
+  return (intSignal & IM21_SIGNAL_BIT.BATTERY) > 0
+}
+
+// Expects to be given a hexidecimal string
+// Returns a boolean
+function isOpen(signal) {
+  const intSignal = parseInt(signal, 16)
+  return (intSignal & IM21_SIGNAL_BIT.STATE) > 0
+}
+
+// Expects to be given a hexidecimal string
+// Returns a boolean
+function isTampered(signal) {
+  const intSignal = parseInt(signal, 16)
+  return (intSignal & IM21_SIGNAL_BIT.TAMPERED) > 0
+}
+
+// Expects to be given true/false values
+// Returns a 2-digit hexidecimal string
+function createSignal(isHeartbeat, isBatteryLow, isDoorOpen, isTamperedWith) {
+  let signal = 0
+  if (isHeartbeat) {
+    signal += IM21_SIGNAL_BIT.HEARTBEAT
+  }
+  if (isBatteryLow) {
+    signal += IM21_SIGNAL_BIT.BATTERY
+  }
+  if (isDoorOpen) {
+    signal += IM21_SIGNAL_BIT.STATE
+  }
+  if (isTamperedWith) {
+    signal += IM21_SIGNAL_BIT.TAMPERED
+  }
+  return signal.toString(16).toUpperCase().padStart(2, '0')
+}
+
+function createOpenSignal() {
+  return createSignal(false, false, true, false)
+}
+
+function createClosedSignal() {
+  return createSignal(false, false, false, false)
+}
+
+module.exports = {
+  createClosedSignal,
+  createOpenSignal,
+  isLowBattery,
+  isOpen,
+  isTampered,
+}

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const SENSOR_EVENT = require('./SensorEventEnum')
 const RADAR_TYPE = require('./RadarTypeEnum')
 const BraveAlerterConfigurator = require('./BraveAlerterConfigurator')
 const im21door = require('./im21door')
-const DOOR_STATUS = require('./SessionStateDoorEnum')
+const DOOR_STATE = require('./SessionStateDoorEnum')
 const routes = require('./routes')
 const dashboard = require('./dashboard')
 
@@ -352,7 +352,7 @@ app.post('/api/door', Validator.body(['coreid', 'data']).exists(), async (reques
         const signal = message.data
         const control = message.control
 
-        const doorSignal = im21door.isOpen(signal) ? DOOR_STATUS.OPEN : DOOR_STATUS.CLOSED
+        const doorSignal = im21door.isOpen(signal) ? DOOR_STATE.OPEN : DOOR_STATE.CLOSED
         await redis.addIM21DoorSensorData(locationid, doorSignal, control)
 
         if (im21door.isLowBattery(signal)) {

--- a/smokeTest.js
+++ b/smokeTest.js
@@ -1,11 +1,14 @@
-const { helpers } = require('brave-alert-lib')
+// Third-party dependencies
 const axios = require('axios').default
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
 const { getRandomArbitrary, getRandomInt } = require('./testingHelpers')
 const RADAR_TYPE = require('./RadarTypeEnum')
 const XETHRU_STATE = require('./SessionStateXethruEnum')
+const im21door = require('./im21door')
 
 const MOV_THRESHOLD = 17
-const IM21_DOOR_STATUS = require('./IM21DoorStatusEnum')
 
 const door_coreID = 'door_coreID'
 const radar_coreID = 'radar_coreID'
@@ -92,11 +95,11 @@ async function smokeTest(recipientPhoneNumber, twilioPhoneNumber) {
     for (let i = 0; i < 15; i += 1) {
       await xeThruMovement(radar_coreID, getRandomInt(MOV_THRESHOLD + 1, 100), getRandomInt(MOV_THRESHOLD + 1, 100))
     }
-    await im21Door(door_coreID, IM21_DOOR_STATUS.OPEN)
+    await im21Door(door_coreID, im21door.createOpenSignal())
     for (let i = 0; i < 5; i += 1) {
       await xeThruMovement(radar_coreID, getRandomInt(0, MOV_THRESHOLD), getRandomInt(0, MOV_THRESHOLD))
     }
-    await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+    await im21Door(door_coreID, im21door.createClosedSignal())
     for (let i = 0; i < 15; i += 1) {
       await xeThruMovement(radar_coreID, getRandomInt(0, MOV_THRESHOLD), getRandomInt(0, MOV_THRESHOLD))
     }

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 const { ALERT_TYPE, helpers } = require('brave-alert-lib')
 const { sleep } = require('brave-alert-lib/lib/helpers')
 const imports = require('../../index')
+const im21door = require('../../im21door')
 
 const db = imports.db
 const redis = imports.redis
@@ -23,7 +24,6 @@ const MOVEMENT_THRESHOLD = 40
 const INITIAL_TIMER = 1
 const STILLNESS_TIMER = 1.5
 const DURATION_TIMER = 3
-const IM21_DOOR_STATUS = require('../../IM21DoorStatusEnum')
 const { getRandomArbitrary, getRandomInt, printRandomIntArray, clientFactory } = require('../../testingHelpers')
 const STATE = require('../../stateMachine/SessionStateEnum')
 
@@ -282,7 +282,7 @@ describe('Brave Sensor server', () => {
       )
       sandbox.stub(braveAlerter, 'startAlertSession')
       sandbox.stub(braveAlerter, 'sendSingleAlert')
-      await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+      await im21Door(door_coreID, im21door.createClosedSignal())
     })
 
     afterEach(async () => {
@@ -336,7 +336,7 @@ describe('Brave Sensor server', () => {
       for (let i = 0; i < 20; i += 1) {
         await xeThruMovement(radar_coreID, getRandomInt(MOVEMENT_THRESHOLD + 1, 100), getRandomInt(MOVEMENT_THRESHOLD + 1, 100))
       }
-      await im21Door(door_coreID, IM21_DOOR_STATUS.OPEN)
+      await im21Door(door_coreID, im21door.createOpenSignal())
       const radarRows = await redis.getXethruStream(testLocation1Id, '+', '-')
       expect(radarRows.length).to.equal(20)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
@@ -402,7 +402,7 @@ describe('Brave Sensor server', () => {
         false,
         client.id,
       )
-      await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+      await im21Door(door_coreID, im21door.createClosedSignal())
       sandbox.spy(StateMachine, 'getNextState')
     })
 
@@ -483,7 +483,7 @@ describe('Brave Sensor server', () => {
         false,
         client.id,
       )
-      await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+      await im21Door(door_coreID, im21door.createClosedSignal())
       sandbox.spy(StateMachine, 'getNextState')
       sandbox.stub(braveAlerter, 'startAlertSession')
       sandbox.stub(braveAlerter, 'sendSingleAlert')
@@ -540,7 +540,7 @@ describe('Brave Sensor server', () => {
       for (let i = 0; i < 20; i += 1) {
         await innosentMovement(radar_coreID, getRandomInt(MOVEMENT_THRESHOLD + 1, 100), getRandomInt(MOVEMENT_THRESHOLD + 1, 100))
       }
-      await im21Door(door_coreID, IM21_DOOR_STATUS.OPEN)
+      await im21Door(door_coreID, im21door.createOpenSignal())
       const radarRows = await redis.getInnosentStream(testLocation1Id, '+', '-')
       expect(radarRows.length).to.equal(300)
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
@@ -606,7 +606,7 @@ describe('Brave Sensor server', () => {
         false,
         client.id,
       )
-      await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+      await im21Door(door_coreID, im21door.createClosedSignal())
     })
 
     afterEach(async () => {
@@ -655,7 +655,7 @@ describe('Brave Sensor server', () => {
   })
 
   describe('Express validation of API and form endpoints', () => {
-    describe('api/door endpoint', () => {
+    describe('/api/door endpoint', () => {
       beforeEach(async () => {
         await redis.clearKeys()
         await db.clearSessions()
@@ -684,7 +684,7 @@ describe('Brave Sensor server', () => {
           false,
           client.id,
         )
-        await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+        await im21Door(door_coreID, im21door.createClosedSignal())
       })
 
       afterEach(async () => {
@@ -698,7 +698,7 @@ describe('Brave Sensor server', () => {
       it('should return 200 for a valid request', async () => {
         const goodRequest = {
           coreid: door_coreID,
-          data: `{ "data": "${IM21_DOOR_STATUS.CLOSED}", "control": "86"}`,
+          data: `{ "data": "${im21door.createClosedSignal()}", "control": "86"}`,
         }
 
         const response = await chai.request(server).post('/api/door').send(goodRequest)
@@ -707,7 +707,7 @@ describe('Brave Sensor server', () => {
 
       it('should return 200 for a request that does not contain coreid', async () => {
         const badRequest = {
-          data: `{ "data": "${IM21_DOOR_STATUS.CLOSED}", "control": "86"}`,
+          data: `{ "data": "${im21door.createClosedSignal()}", "control": "86"}`,
         }
 
         const response = await chai.request(server).post('/api/door').send(badRequest)
@@ -753,7 +753,7 @@ describe('Brave Sensor server', () => {
           false,
           client.id,
         )
-        await im21Door(door_coreID, IM21_DOOR_STATUS.CLOSED)
+        await im21Door(door_coreID, im21door.createClosedSignal())
       })
 
       afterEach(async () => {

--- a/test/unit/im21doorTest.js
+++ b/test/unit/im21doorTest.js
@@ -1,0 +1,95 @@
+const { expect } = require('chai')
+const { describe, it } = require('mocha')
+const im21door = require('../../im21door')
+
+describe('im21door.js unit tests', () => {
+  describe('isLowBattery', () => {
+    it('should return true if and only if bit-2 is 1', () => {
+      const testCases = [
+        { inputSignal: '00', expected: false },
+        { inputSignal: '01', expected: false },
+        { inputSignal: '02', expected: false },
+        { inputSignal: '03', expected: false },
+        { inputSignal: '04', expected: true },
+        { inputSignal: '05', expected: true },
+        { inputSignal: '06', expected: true },
+        { inputSignal: '07', expected: true },
+        { inputSignal: '08', expected: false },
+        { inputSignal: '09', expected: false },
+        { inputSignal: '0A', expected: false },
+        { inputSignal: '0B', expected: false },
+        { inputSignal: '0C', expected: true },
+        { inputSignal: '0D', expected: true },
+        { inputSignal: '0E', expected: true },
+        { inputSignal: '0F', expected: true },
+      ]
+      expect(testCases.map(testCase => `${testCase.inputSignal}: ${im21door.isLowBattery(testCase.inputSignal)}`)).to.eql(
+        testCases.map(testCase => `${testCase.inputSignal}: ${testCase.expected}`),
+      )
+    })
+  })
+
+  describe('isOpen', () => {
+    it('should return true if and only if bit-1 is 1', () => {
+      const testCases = [
+        { inputSignal: '00', expected: false },
+        { inputSignal: '01', expected: false },
+        { inputSignal: '02', expected: true },
+        { inputSignal: '03', expected: true },
+        { inputSignal: '04', expected: false },
+        { inputSignal: '05', expected: false },
+        { inputSignal: '06', expected: true },
+        { inputSignal: '07', expected: true },
+        { inputSignal: '08', expected: false },
+        { inputSignal: '09', expected: false },
+        { inputSignal: '0A', expected: true },
+        { inputSignal: '0B', expected: true },
+        { inputSignal: '0C', expected: false },
+        { inputSignal: '0D', expected: false },
+        { inputSignal: '0E', expected: true },
+        { inputSignal: '0F', expected: true },
+      ]
+      expect(testCases.map(testCase => `${testCase.inputSignal}: ${im21door.isOpen(testCase.inputSignal)}`)).to.eql(
+        testCases.map(testCase => `${testCase.inputSignal}: ${testCase.expected}`),
+      )
+    })
+  })
+
+  describe('isTampered', () => {
+    it('should return true if and only if bit-0 is 1', () => {
+      const testCases = [
+        { inputSignal: '00', expected: false },
+        { inputSignal: '01', expected: true },
+        { inputSignal: '02', expected: false },
+        { inputSignal: '03', expected: true },
+        { inputSignal: '04', expected: false },
+        { inputSignal: '05', expected: true },
+        { inputSignal: '06', expected: false },
+        { inputSignal: '07', expected: true },
+        { inputSignal: '08', expected: false },
+        { inputSignal: '09', expected: true },
+        { inputSignal: '0A', expected: false },
+        { inputSignal: '0B', expected: true },
+        { inputSignal: '0C', expected: false },
+        { inputSignal: '0D', expected: true },
+        { inputSignal: '0E', expected: false },
+        { inputSignal: '0F', expected: true },
+      ]
+      expect(testCases.map(testCase => `${testCase.inputSignal}: ${im21door.isTampered(testCase.inputSignal)}`)).to.eql(
+        testCases.map(testCase => `${testCase.inputSignal}: ${testCase.expected}`),
+      )
+    })
+  })
+
+  describe('createOpenSignal', () => {
+    it('should return a 2-digit hex string indicating that a door was opened', () => {
+      expect(im21door.createOpenSignal()).to.equal('02')
+    })
+  })
+
+  describe('createClosedSignal', () => {
+    it('should return a 2-digit hex string indicating that the door was closed', () => {
+      expect(im21door.createClosedSignal()).to.equal('00')
+    })
+  })
+})


### PR DESCRIPTION
- We were relying on specific, hardcoded values for the signal coming in from the IM21 door sensor. However, the IM21 specs explain the value as a bit map. Changed the code to use similar logic.
- This fixes a problem where we were missing Door Open and Door Close events that occur when the battery is low
- No longer stores 'LowBatt' as a door signal value in Redis because this was only ever working when it was a low battery and the door was closed. It would not have worked if the door were open. We also weren't using this information for anything that I can see.
- Rename DOOR_STATUS to DOOR_STATE wherever it's used for consistency with the `SessionStateDoorEnum.js` file and the other places where the enum is used.
- Added a Sentry log if the door sensor sends us the tamper bit on.

## Test Plan
- :heavy_check_mark: Deploy to dev.sensors.brave.coop
- :heavy_check_mark: Run the smoke tests
- :heavy_check_mark: Open and close the door of my actual bathroom
   - :heavy_check_mark: 'open' and 'closed' values appear in Redis for my XeThru+SSM device
   - :heavy_check_mark: My XeThru+SSM device logs a transition from IDLE to INITIAL TIMER when I close the door
   - :heavy_check_mark: My XeThru+SSM device logs a  transition to IDLE when I open the door
- :heavy_check_mark: Using Postman, send signals '00' to '0F' to the `POST /api/door` endpoint for my XeThru+SSM device and look for the expected reactions in:
   - :heavy_check_mark: Redis door states
   - :heavy_check_mark: Logged transitions
   - :heavy_check_mark: Text messages
   - :heavy_check_mark: Sentry messages