### PR TITLE
Brave Siren Milestone2 (CU-1dffcm4)

### DIFF
--- a/db/db.js
+++ b/db/db.js
@@ -394,7 +394,7 @@ async function getLocationFromParticleCoreID(coreID, clientParam) {
   try {
     const results = await runQuery(
       'getLocationFromParticleCoreID',
-      'SELECT * FROM locations WHERE door_particlecoreid = $1 OR radar_particlecoreid = $1',
+      'SELECT * FROM locations WHERE door_particlecoreid = $1 OR radar_particlecoreid = $1 OR siren_particle_id = $1',
       [coreID],
       clientParam,
     )

--- a/index.js
+++ b/index.js
@@ -485,7 +485,7 @@ app.post('/api/heartbeat', Validator.body(['coreid', 'event', 'data']).exists(),
   }
 })
 
-app.post('/api/sirenAddressed', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
+app.post('/api/sirenAddressed', Validator.body(['coreid']).exists(), async (request, response) => {
   try {
     const validationErrors = Validator.validationResult(request).formatWith(helpers.formatExpressValidationErrors)
 
@@ -514,7 +514,7 @@ app.post('/api/sirenAddressed', Validator.body(['coreid', 'event', 'data']).exis
             session.chatbotState = CHATBOT_STATE.COMPLETED
             await db.saveSession(session, client)
           } else {
-            helpers.logError(`Error stopping session and chatbot due to siren button press`)
+            helpers.logError(`Error stopping session and chatbot due to siren ${coreId} button press`)
           }
 
           await db.commitTransaction(client)
@@ -543,7 +543,7 @@ app.post('/api/sirenAddressed', Validator.body(['coreid', 'event', 'data']).exis
   }
 })
 
-app.post('/api/sirenEscalated', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
+app.post('/api/sirenEscalated', Validator.body(['coreid']).exists(), async (request, response) => {
   try {
     const validationErrors = Validator.validationResult(request).formatWith(helpers.formatExpressValidationErrors)
 

--- a/index.js
+++ b/index.js
@@ -482,7 +482,7 @@ app.post('/api/heartbeat', Validator.body(['coreid', 'event', 'data']).exists(),
   }
 })
 
-app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
+app.post('/api/sirenAddressed', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
   try {
     const validationErrors = Validator.validationResult(request).formatWith(helpers.formatExpressValidationErrors)
 
@@ -501,26 +501,27 @@ app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exi
         try {
           client = await db.beginTransaction()
           if (client === null) {
-            helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
+            helpers.logError(`sirenAddressedCallback: Error starting transaction`)
             return
           }
 
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
             session.respondedAt = await db.getCurrentTime(client)
+            session.chatbotState = CHATBOT_STATE.COMPLETED
             await db.saveSession(session, client)
           } else {
-            helpers.logError(`error stopping session and chatbot due to siren button press`)
+            helpers.logError(`Error stopping session and chatbot due to siren button press`)
           }
 
           await db.commitTransaction(client)
         } catch (e) {
           try {
             await db.rollbackTransaction(client)
-            helpers.logError(`alertSessionChangedCallback: Rolled back transaction because of error: ${e}`)
+            helpers.logError(`sirenAddressedCallback: Rolled back transaction because of error: ${e}`)
           } catch (error) {
             // Do nothing
-            helpers.logError(`alertSessionChangedCallback: Error rolling back transaction: ${e}`)
+            helpers.logError(`sirenAddressedCallback: Error rolling back transaction: ${e}`)
           }
         }
         response.status(200).json('OK')
@@ -539,7 +540,7 @@ app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exi
   }
 })
 
-app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
+app.post('/api/sirenEscalated', Validator.body(['coreid', 'event', 'data']).exists(), async (request, response) => {
   try {
     const validationErrors = Validator.validationResult(request).formatWith(helpers.formatExpressValidationErrors)
 
@@ -558,7 +559,7 @@ app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exis
         try {
           client = await db.beginTransaction()
           if (client === null) {
-            helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
+            helpers.logError(`sirenEscalatedCallback: Error starting transaction`)
             return
           }
 
@@ -574,10 +575,10 @@ app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exis
         } catch (e) {
           try {
             await db.rollbackTransaction(client)
-            helpers.logError(`alertSessionChangedCallback: Rolled back transaction because of error: ${e}`)
+            helpers.logError(`sirenEscalatedCallback: Rolled back transaction because of error: ${e}`)
           } catch (error) {
             // Do nothing
-            helpers.logError(`alertSessionChangedCallback: Error rolling back transaction: ${e}`)
+            helpers.logError(`sirenEscalatedCallback: Error rolling back transaction: ${e}`)
           }
         }
         response.status(200).json('OK')

--- a/index.js
+++ b/index.js
@@ -569,6 +569,19 @@ app.post('/api/sirenEscalated', Validator.body(['coreid', 'event', 'data']).exis
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
             session.chatbotState = CHATBOT_STATE.STARTED
+            const alertInfo = {
+              sessionId: session.id,
+              toPhoneNumber: location.responderPhoneNumber,
+              fromPhoneNumber: location.twilioNumber,
+              message: `This is a ${alertTypeDisplayName} alert. Please check on the bathroom at ${location.displayName}. Please respond with 'ok' once you have checked on it.`,
+              reminderTimeoutMillis: location.reminderTimer,
+              fallbackTimeoutMillis: location.fallbackTimer,
+              reminderMessage: `This is a reminder to check on the bathroom`,
+              fallbackMessage: `An alert to check on the bathroom at ${location.displayName} was not responded to. Please check on it`,
+              fallbackToPhoneNumbers: location.fallbackNumbers,
+              fallbackFromPhoneNumber: location.client.fromPhoneNumber,
+            }
+            braveAlerter.startAlertSession(alertInfo)
             await db.saveSession(session, client)
           } else {
             helpers.logError(`Siren not responded to - error starting normal chatbot`)

--- a/index.js
+++ b/index.js
@@ -568,7 +568,6 @@ app.post('/api/sirenEscalated', Validator.body(['coreid', 'event', 'data']).exis
 
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
-            session.chatbotState = CHATBOT_STATE.STARTED
             const alertInfo = {
               sessionId: session.id,
               toPhoneNumber: location.responderPhoneNumber,

--- a/index.js
+++ b/index.js
@@ -509,7 +509,6 @@ app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exi
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
             session.respondedAt = await db.getCurrentTime(client)
-            session.chatbotState = CHATBOT_STATE.COMPLETED    
             await db.saveSession(session, client)
           } else {
             helpers.logError(`error stopping session and chatbot due to siren button press`)

--- a/index.js
+++ b/index.js
@@ -568,8 +568,8 @@ app.post('/api/sirenEscalated', Validator.body(['coreid']).exists(), async (requ
 
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
-            alertMessage= 'There is an unresponded siren. Please check on the bathroom at ${location.displayName}.'
-            braveAlerter.sendSingleAlert(location.responderPhoneNumber,location.twilioNumber,alertMessage)
+            const alertMessage = `There is an unresponded siren. Please check on the bathroom at ${location.displayName}.`
+            braveAlerter.sendSingleAlert(location.responderPhoneNumber, location.twilioNumber, alertMessage)
             await db.saveSession(session, client)
           } else {
             helpers.logError(`Siren not responded to - error starting normal chatbot`)

--- a/index.js
+++ b/index.js
@@ -573,7 +573,7 @@ app.post('/api/sirenEscalated', Validator.body(['coreid', 'event', 'data']).exis
               sessionId: session.id,
               toPhoneNumber: location.responderPhoneNumber,
               fromPhoneNumber: location.twilioNumber,
-              message: `This is a ${alertTypeDisplayName} alert. Please check on the bathroom at ${location.displayName}. Please respond with 'ok' once you have checked on it.`,
+              message: `This is an unresponded siren alert. Please check on the bathroom at ${location.displayName}. Please respond with 'ok' once you have checked on it.`,
               reminderTimeoutMillis: location.reminderTimer,
               fallbackTimeoutMillis: location.fallbackTimer,
               reminderMessage: `This is a reminder to check on the bathroom`,

--- a/index.js
+++ b/index.js
@@ -489,14 +489,13 @@ app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exi
     if (validationErrors.isEmpty()) {
       const coreId = request.body.coreid
       const location = await db.getLocationFromParticleCoreID(coreId)
-      
+
       if (!location) {
         const errorMessage = `Bad request to ${request.path}: no location matches the coreID ${coreId}`
         helpers.logError(errorMessage)
         // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
         response.status(200).json(errorMessage)
       } else {
-        const message = JSON.parse(request.body.data)
         let client
 
         try {
@@ -513,7 +512,7 @@ app.post('/api/siren-addressed', Validator.body(['coreid', 'event', 'data']).exi
           } else {
             helpers.logError(`error stopping session and chatbot due to siren button press`)
           }
-    
+
           await db.commitTransaction(client)
         } catch (e) {
           try {
@@ -547,14 +546,13 @@ app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exis
     if (validationErrors.isEmpty()) {
       const coreId = request.body.coreid
       const location = await db.getLocationFromParticleCoreID(coreId)
-      
+
       if (!location) {
         const errorMessage = `Bad request to ${request.path}: no location matches the coreID ${coreId}`
         helpers.logError(errorMessage)
         // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
         response.status(200).json(errorMessage)
       } else {
-        const message = JSON.parse(request.body.data)
         let client
 
         try {
@@ -566,12 +564,12 @@ app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exis
 
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
-            session.chatbotState = CHATBOT_STATE.STARTED    
+            session.chatbotState = CHATBOT_STATE.STARTED
             await db.saveSession(session, client)
           } else {
             helpers.logError(`Siren not responded to - error starting normal chatbot`)
           }
-    
+
           await db.commitTransaction(client)
         } catch (e) {
           try {
@@ -597,8 +595,6 @@ app.post('/api/siren-escalate', Validator.body(['coreid', 'event', 'data']).exis
     response.status(200).json(errorMessage)
   }
 })
-
-
 
 app.post('/smokeTest/setup', async (request, response) => {
   const { recipientNumber, twilioNumber, radarType } = request.body

--- a/index.js
+++ b/index.js
@@ -568,19 +568,8 @@ app.post('/api/sirenEscalated', Validator.body(['coreid']).exists(), async (requ
 
           const session = await db.getUnrespondedSessionWithLocationId(location.locationid, client)
           if (session) {
-            const alertInfo = {
-              sessionId: session.id,
-              toPhoneNumber: location.responderPhoneNumber,
-              fromPhoneNumber: location.twilioNumber,
-              message: `This is an unresponded siren alert. Please check on the bathroom at ${location.displayName}. Please respond with 'ok' once you have checked on it.`,
-              reminderTimeoutMillis: location.reminderTimer,
-              fallbackTimeoutMillis: location.fallbackTimer,
-              reminderMessage: `This is a reminder to check on the bathroom`,
-              fallbackMessage: `An alert to check on the bathroom at ${location.displayName} was not responded to. Please check on it`,
-              fallbackToPhoneNumbers: location.fallbackNumbers,
-              fallbackFromPhoneNumber: location.client.fromPhoneNumber,
-            }
-            braveAlerter.startAlertSession(alertInfo)
+            alertMessage= 'There is an unresponded siren. Please check on the bathroom at ${location.displayName}.'
+            braveAlerter.sendSingleAlert(location.responderPhoneNumber,location.twilioNumber,alertMessage)
             await db.saveSession(session, client)
           } else {
             helpers.logError(`Siren not responded to - error starting normal chatbot`)

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -276,7 +276,7 @@ describe('Brave Sensor server', () => {
       await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
       await sirenAddressedAlert('particleCoreIdTest')
       const session = await db.getMostRecentSession(testLocation1Id)
-      expect(session.chatbotState).to.have.status(CHATBOT_STATE.COMPLETED)
+      expect(session.chatbotState).to.equal(CHATBOT_STATE.COMPLETED)
     })
 
     it('should not call startAlertSession if particleSirenID is not null', async () => {

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -27,6 +27,7 @@ const STILLNESS_TIMER = 1.5
 const DURATION_TIMER = 3
 const { getRandomArbitrary, getRandomInt, printRandomIntArray, clientFactory } = require('../../testingHelpers')
 const STATE = require('../../stateMachine/SessionStateEnum')
+const { getMostRecentSession } = require('../../db/db')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)
@@ -273,8 +274,9 @@ describe('Brave Sensor server', () => {
 
     it('should make the chatbot state completed after an addressed alert', async () => {
       await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
-      const response = await sirenAddressedAlert('particleCoreIdTest')
-      expect(response).to.have.status(CHATBOT_STATE.COMPLETED)
+      await sirenAddressedAlert('particleCoreIdTest')
+      const session = await db.getMostRecentSession(testLocation1Id)
+      expect(session.chatbotState).to.have.status(CHATBOT_STATE.COMPLETED)
     })
 
     it('should not call startAlertSession if particleSirenID is not null', async () => {

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -242,7 +242,7 @@ describe('Brave Sensor server', () => {
       await chai.request(server).post('/api/sirenEscalated').send({})
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       const session = sessions[sessions.length - 1]
-      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)      
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)
     })
 
     it('should not call startAlertSession if particleSirenID is not null', async () => {

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -227,13 +227,13 @@ describe('Brave Sensor server', () => {
 
     it('should send a 200 response if a sirenAddressed call is receieved', async () => {
       await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
-      await chai.request(server).post('/api/sirenAddressed').send({})
+      const response = await chai.request(server).post('/api/sirenAddressed').send({})
       expect(response).to.have.status(200)
     })
 
     it('should send a 200 response if a sirenEscalated call is receieved', async () => {
       await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
-      await chai.request(server).post('/api/sirenEscalated').send({})
+      const response = await chai.request(server).post('/api/sirenEscalated').send({})
       expect(response).to.have.status(200)
     })
 

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -27,7 +27,6 @@ const STILLNESS_TIMER = 1.5
 const DURATION_TIMER = 3
 const { getRandomArbitrary, getRandomInt, printRandomIntArray, clientFactory } = require('../../testingHelpers')
 const STATE = require('../../stateMachine/SessionStateEnum')
-const { getMostRecentSession } = require('../../db/db')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -225,6 +225,26 @@ describe('Brave Sensor server', () => {
       })
     })
 
+    it('should send a 200 response if a sirenAddressed call is receieved', async () => {
+      await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
+      await chai.request(server).post('/api/sirenAddressed').send({})
+      expect(response).to.have.status(200)
+    })
+
+    it('should send a 200 response if a sirenEscalated call is receieved', async () => {
+      await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
+      await chai.request(server).post('/api/sirenEscalated').send({})
+      expect(response).to.have.status(200)
+    })
+
+    it('should start an alert session if a sirenEscalated call is receieved', async () => {
+      await firmwareAlert(radar_coreID, SENSOR_EVENT.STILLNESS)
+      await chai.request(server).post('/api/sirenEscalated').send({})
+      const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
+      const session = sessions[sessions.length - 1]
+      expect(session.alertType).to.equal(ALERT_TYPE.SENSOR_STILLNESS)      
+    })
+
     it('should not call startAlertSession if particleSirenID is not null', async () => {
       const sessions = await db.getAllSessionsFromLocation(testLocation1Id)
       expect(sessions.length).to.equal(0)


### PR DESCRIPTION
Added two app.post handlers for messages from the siren particle.

"addressed" handler:
Siren particle calls this when a responder pushes the physical button on the Brave Siren. This handler should stop the current alert session.

"escalate" handler:
Siren particle calls this when a responder does NOT push the physical button on the Brave Siren before the timer in the particle firmware runs out. This handler should start the normal chatbot.
