### PR TITLE
Changes needed for OneSignal Push Notification (CU-10xfkhr)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,11 @@ PARTICLE_ACCESS_TOKEN_TEST=particle_access_token_test
 # Particle Product group ID or slug (https://docs.particle.io/reference/SDKs/javascript/#product-support)
 PARTICLE_PRODUCT_GROUP=product-123
 PARTICLE_PRODUCT_GROUP_TEST=product-123
+
+# OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> OneSignal App ID
+ONESIGNAL_APP_ID=guid-here
+ONESIGNAL_APP_ID_TEST=guid-here
+
+# OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> REST API Key
+ONESIGNAL_API_KEY=jumbleOfCharactersHere
+ONESIGNAL_API_KEY_TEST=jumbleOfCharactersHere

--- a/BraveAlerterConfigurator.js
+++ b/BraveAlerterConfigurator.js
@@ -30,7 +30,7 @@ class BraveAlerterConfigurator {
       session.incidentType,
       undefined,
       `An alert to check on the washroom at ${locationData.displayName} was not responded to. Please check on it`,
-      locationData.responderPhoneNumber,
+      locationData.client.responderPhoneNumber,
       incidentTypeKeys,
       incidentTypes,
     )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ the code was deployed.
 - `POST /api/sirenAddressed` to handle when a Brave Siren's button is pressed (CU-1dffcm4).
 - `POST /api/sirenEscalated` to handled when a Brave Siren times out and it wants to escalate the alert to the Fallback phones (CU-1dffcm4).
 - `responder_push_id` to the DB to store the Responder Device's Push Notification ID (CU-10xfkhr).
+- `POST /alert/acknowledgeAlertSession` to acknowledge an alert session through the Alert App (CU-10xfkhr).
+- `POST /alert/respondToAlertSession` to respond to an alert session through the Alert App (CU-10xfkhr).
+- `POST /alert/setIncidentCategory` to set the incident category for an alert session through the Alert App (CU-10xfkhr).
+- `GET /alert/activeAlerts` endpoint (CU-10xfkhr).
 
 ## [4.1.0] - 2021-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 - Added Particle cloud function call to start siren in case of alert (CU-18r17vf).
 - `POST /api/sirenAddressed` to handle when a Brave Siren's button is pressed (CU-1dffcm4).
 - `POST /api/sirenEscalated` to handled when a Brave Siren times out and it wants to escalate the alert to the Fallback phones (CU-1dffcm4).
+- `responder_push_id` to the DB to store the Responder Device's Push Notification ID (CU-10xfkhr).
 
 ## [4.1.0] - 2021-08-30
 

--- a/Client.js
+++ b/Client.js
@@ -1,9 +1,12 @@
 class Client {
   // prettier-ignore
-  constructor(id, displayName, fromPhoneNumber, createdAt, updatedAt) {
+  constructor(id, displayName, fromPhoneNumber, responderPhoneNumber, responderPushId, alertApiKey, createdAt, updatedAt) {
     this.id = id
     this.displayName = displayName
     this.fromPhoneNumber = fromPhoneNumber
+    this.responderPhoneNumber = responderPhoneNumber
+    this.responderPushId = responderPushId
+    this.alertApiKey = alertApiKey
     this.createdAt = createdAt
     this.updatedAt = updatedAt
   }

--- a/Location.js
+++ b/Location.js
@@ -1,9 +1,8 @@
 class Location {
   // prettier-ignore
-  constructor(locationid, displayName, responderPhoneNumber, movementThreshold, durationTimer, stillnessTimer, heartbeatSentAlerts, heartbeatAlertRecipients, doorCoreId, radarCoreId, radarType, reminderTimer, fallbackTimer, twilioNumber, fallbackNumbers, initialTimer, alertApiKey, isActive, firmwareStateMachine, sirenParticleId, client) {
+  constructor(locationid, displayName, movementThreshold, durationTimer, stillnessTimer, heartbeatSentAlerts, heartbeatAlertRecipients, doorCoreId, radarCoreId, radarType, reminderTimer, fallbackTimer, twilioNumber, fallbackNumbers, initialTimer, isActive, firmwareStateMachine, sirenParticleId, client) {
     this.locationid = locationid
     this.displayName = displayName
-    this.responderPhoneNumber = responderPhoneNumber
     this.movementThreshold = movementThreshold
     this.durationTimer = durationTimer
     this.stillnessTimer = stillnessTimer
@@ -17,7 +16,6 @@ class Location {
     this.twilioNumber = twilioNumber
     this.fallbackNumbers = fallbackNumbers
     this.initialTimer = initialTimer
-    this.alertApiKey = alertApiKey
     this.isActive = isActive
     this.firmwareStateMachine = firmwareStateMachine
     this.client = client

--- a/db/023-add-responder-push-id.sql
+++ b/db/023-add-responder-push-id.sql
@@ -1,0 +1,35 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 23;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- Add new columns
+        ALTER TABLE clients ADD COLUMN responder_phone_number TEXT;
+        ALTER TABLE clients ADD COLUMN alert_api_key TEXT;
+        ALTER TABLE clients ADD COLUMN responder_push_id TEXT;
+
+        -- Set columns in clients based on their values in locations
+        UPDATE clients
+        SET 
+            responder_phone_number = locations.responder_phone_number,
+            alert_api_key = locations.alert_api_key
+        FROM locations
+        WHERE clients.id = locations.client_id;
+
+        -- Remove the columns from locations
+        ALTER TABLE locations DROP COLUMN responder_phone_number;
+        ALTER TABLE locations DROP COLUMN alert_api_key;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/index.js
+++ b/index.js
@@ -480,10 +480,9 @@ app.post('/api/heartbeat', Validator.body(['coreid', 'event', 'data']).exists(),
 app.post('/smokeTest/setup', async (request, response) => {
   const { recipientNumber, twilioNumber, radarType } = request.body
   try {
-    const client = await db.createClient('SmokeTestClient', twilioNumber)
+    const client = await db.createClient('SmokeTestClient', twilioNumber, recipientNumber, null, 'alertApiKey')
     await db.createLocation(
       'SmokeTestLocation',
-      recipientNumber,
       17,
       15,
       150,
@@ -497,7 +496,6 @@ app.post('/smokeTest/setup', async (request, response) => {
       'door_coreID',
       'radar_coreID',
       radarType,
-      'alertApiKey',
       true,
       false,
       null,

--- a/mustache-templates/newClient.mst
+++ b/mustache-templates/newClient.mst
@@ -34,6 +34,27 @@
                         <small id="phoneHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
                     </div>
                 </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="responderPhoneNumber" class="col-sm-3 col-form-label">Responder Phone Number:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="responderPhoneNumber" value="+1" pattern="[+][1]\d{10}">
+                        <small id="responderPhoneNumberHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="responderPushId" class="col-sm-3 col-form-label">Responder Push ID:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="responderPushId" placeholder="Responder Push ID">
+                        <small id="responderPushIdHelp" class="form-text text-muted">Must provide either "Responder Phone Number" or ("Responder Push ID" and "Alert App API Key")</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="alertApiKey" class="col-sm-3 col-form-label">Alert App API Key:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="alertApiKey" placeholder="API Key">
+                        <small id="alertApiKeyHelp" class="form-text text-muted">Must provide either "Responder Phone Number" or ("Responder Push ID" and "Alert App API Key")</small>
+                    </div>
+                </div>
                 <br>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>

--- a/mustache-templates/newLocation.mst
+++ b/mustache-templates/newLocation.mst
@@ -25,7 +25,7 @@
                     <label for="locationid" class="col-sm-3 col-form-label">Location ID:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="locationid" placeholder="Location ID" required pattern="^[\S]+$">
-                        <small id="phoneHelp" class="form-text text-muted">No spaces, please</small>
+                        <small id="locationidHelp" class="form-text text-muted">No spaces, please</small>
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
@@ -63,20 +63,6 @@
                             <option value="XeThru">XeThru</option>
                             <option value="Innosent">Innosent</option>
                         </select>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="responderPhoneNumber" class="col-sm-3 col-form-label">Responder Phone Number:</label>
-                    <div class="col-sm-5">
-                        <input type="text" class="form-control" name="responderPhoneNumber" value="+1" pattern="[+][1]\d{10}">
-                        <small id="phoneHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="alertApiKey" class="col-sm-3 col-form-label">Alert App API Key:</label>
-                    <div class="col-sm-5">
-                        <input type="text" class="form-control" name="alertApiKey" placeholder="API Key">
-                        <small id="alertApiKeyHelp" class="form-text text-muted">Must provide one or both of "Responder Phone Number" and "Alert App API Key"</small>
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">

--- a/mustache-templates/updateClient.mst
+++ b/mustache-templates/updateClient.mst
@@ -40,6 +40,27 @@
                         <small id="phoneHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
                     </div>
                 </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="responderPhoneNumber" class="col-sm-3 col-form-label">Responder Phone Number:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="responderPhoneNumber" value="{{responderPhoneNumber}}" pattern="[+][1]\d{10}">
+                        <small id="responderPhoneNumberHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="responderPushId" class="col-sm-3 col-form-label">Responder Push ID:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="responderPushId" placeholder="Responder Push ID" value={{responderPushId}}>
+                        <small id="responderPushIdHelp" class="form-text text-muted">Must provide either "Responder Phone Number" or ("Responder Push ID" and "Alert App API Key")</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="alertApiKey" class="col-sm-3 col-form-label">Alert App API Key:</label>
+                    <div class="col-sm-5">
+                        <input type="text" class="form-control" name="alertApiKey" placeholder="API Key" value="{{alertApiKey}}">
+                        <small id="alertApiKeyHelp" class="form-text text-muted">Must provide either "Responder Phone Number" or ("Responder Push ID" and "Alert App API Key")</small>
+                    </div>
+                </div>
                 <br>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>

--- a/mustache-templates/updateLocation.mst
+++ b/mustache-templates/updateLocation.mst
@@ -65,20 +65,6 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="phone" class="col-sm-3 col-form-label">Responder Phone Number:</label>
-                    <div class="col-sm-5">
-                        <input type="text" class="form-control" name="responderPhoneNumber" value="{{responderPhoneNumber}}" pattern="[+][1]\d{10}">
-                        <small id="phoneHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="alertApiKey" class="col-sm-3 col-form-label">Alert App API Key:</label>
-                    <div class="col-sm-5">
-                        <input type="text" class="form-control" name="alertApiKey" placeholder="API Key" value="{{alertApiKey}}">
-                        <small id="alertApiKeyHelp" class="form-text text-muted">Must provide one or both of "Responder Phone Number" and "Alert App API Key"</small>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="fallbackPhones" class="col-sm-3 col-form-label">Fallback Phone Numbers:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="fallbackPhones" value="{{fallbackNumbers}}" required pattern="[+][1]\d{10}([,][+][1]\d{10})*">
@@ -86,7 +72,7 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="heartbeatPhone" class="col-sm-3 col-form-label">Heartbeat Phone Number:</label>
+                    <label for="heartbeatPhone" class="col-sm-3 col-form-label">Heartbeat Phone Numbers:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="heartbeatPhones" value="{{heartbeatAlertRecipients}}" required pattern="[+][1]\d{10}([,][+][1]\d{10})*">
                         <small id="heartbeatPhoneHelp" class="form-text text-muted">Each phone number has +1 in front and separated by commas with no dashes or spaces, please (eg. +14445556789,+12223334444,+11231231234)</small>

--- a/package-lock.json
+++ b/package-lock.json
@@ -700,11 +700,12 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v4.0.0",
-      "from": "brave-alert-lib@git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v4.0.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#57f7bd3ea8727c971120c104437c896b2f1495cf",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-fix-error-message",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
+        "axios": "^0.21.2",
         "body-parser": "^1.19.0",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
@@ -1034,9 +1035,9 @@
       }
     },
     "dayjs": {
-      "version": "1.10.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
-      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz",
+      "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
       "version": "4.3.1",
@@ -4238,9 +4239,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.66.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.66.0.tgz",
-      "integrity": "sha512-2jek7akXcRMusoR20EWA1+e5TQp9Ahosvo81wTUoeS7H24A1xbVQJV4LfSWQN4DLUY1oZ4d6tH2oCe/+ELcpNA==",
+      "version": "3.68.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.68.0.tgz",
+      "integrity": "sha512-xVFx/TbibpQtYwkDzuqPS8fsBGg8ZZ2iUtGU68dC9Dv1cngmxePcvxmyFxgPEd6wpnexJHHrCyiSr+LBaBEcDg==",
       "requires": {
         "axios": "^0.21.1",
         "dayjs": "^1.8.29",
@@ -4251,7 +4252,7 @@
         "qs": "^6.9.4",
         "rootpath": "^0.1.2",
         "scmp": "^2.1.0",
-        "url-parse": "^1.5.0",
+        "url-parse": "^1.5.3",
         "xmlbuilder": "^13.0.2"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
     "body-parser": "^1.19.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v4.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-fix-error-message",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/sensor-helm-chart/templates/sensor-deployment.yaml
+++ b/sensor-helm-chart/templates/sensor-deployment.yaml
@@ -124,6 +124,16 @@ spec:
               secretKeyRef:
                 name: {{ .Values.secretName | quote }}
                 key: PARTICLE_PRODUCT_GROUP
+          - name: ONESIGNAL_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretName | quote }}
+                key: ONESIGNAL_APP_ID
+          - name: ONESIGNAL_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretName | quote }}
+                key: ONESIGNAL_API_KEY
           - name: ENVIRONMENT
             value: {{ include "sensor.fullname" . | quote }}
           - name: RELEASE

--- a/setup_postgresql.sh
+++ b/setup_postgresql.sh
@@ -21,3 +21,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/020-add-responded-at-to-sessions.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/021-add-client-from-phone-number.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/022-add-siren-particle-id.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/023-add-responder-push-id.sql

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -21,10 +21,9 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
     this.expectedTwilioPhoneNumber = '+3336661234'
 
     // Insert a location in the DB
-    const client = await clientFactory(db)
+    const client = await clientFactory(db, { responderPhoneNumber: this.expectedLocationPhoneNumber })
     await db.createLocation(
       'LocationId',
-      this.expectedLocationPhoneNumber,
       1,
       1,
       1,
@@ -38,7 +37,6 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
       'DoorCoreId',
       'RadarCoreId',
       'XeThru',
-      'alertApiKey',
       true,
       false,
       null,

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionByPhoneNumberTest.js
@@ -10,9 +10,7 @@ const { clientFactory } = require('../../../testingHelpers')
 
 describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneNumber', () => {
   beforeEach(async () => {
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.expectedChatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
     this.expectedIncidentType = 'No One Inside'
@@ -52,9 +50,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSessionByPhoneN
   })
 
   afterEach(async () => {
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
   })
 
   it('should create a new AlertSession with expected values from the sessions and locations DB tables', async () => {

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionIdAndAlertApiKeyTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionBySessionIdAndAlertApiKeyTest.js
@@ -8,7 +8,7 @@ const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
 const { clientFactory } = require('../../../testingHelpers')
 
-describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () => {
+describe('BraveAlerterConfigurator.js integration tests: getAlertSessionBySessionIdAndAlertApiKey', () => {
   beforeEach(async () => {
     await db.clearTables()
 
@@ -16,9 +16,11 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     this.expectedIncidentType = 'No One Inside'
     this.expectedLocationDisplayName = 'TEST LOCATION'
     this.expectedLocationPhoneNumber = '+17772225555'
+    this.expectedTwilioPhoneNumber = '+3336661234'
+    this.alertApiKey = 'myAlertApiKey'
 
     // Insert a location in the DB
-    const client = await clientFactory(db, { responderPhoneNumber: this.expectedLocationPhoneNumber })
+    const client = await clientFactory(db, { responderPhoneNumber: this.expectedLocationPhoneNumber, alertApiKey: this.alertApiKey })
     await db.createLocation(
       'LocationId',
       1,
@@ -27,7 +29,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
       1,
       1,
       [],
-      1,
+      this.expectedTwilioPhoneNumber,
       [],
       1,
       this.expectedLocationDisplayName,
@@ -45,7 +47,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     this.session = await db.createSession(locationId, this.expectedLocationPhoneNumber, ALERT_TYPE.SENSOR_DURATION)
     this.session.chatbotState = this.expectedChatbotState
     this.session.incidentType = this.expectedIncidentType
-    db.saveSession(this.session)
+    await db.saveSession(this.session)
   })
 
   afterEach(async () => {
@@ -54,7 +56,7 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
 
   it('should create a new AlertSession with expected values from the sessions and locations DB tables', async () => {
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
-    const actualAlertSession = await braveAlerterConfigurator.createAlertSessionFromSession(this.session)
+    const actualAlertSession = await braveAlerterConfigurator.getAlertSessionBySessionIdAndAlertApiKey(this.session.id, this.alertApiKey)
 
     const expectedAlertSession = new AlertSession(
       this.session.id,

--- a/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getAlertSessionTest.js
@@ -20,10 +20,9 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
     this.expectedLocationPhoneNumber = '+17772225555'
 
     // Insert a location in the DB
-    const client = await clientFactory(db)
+    const client = await clientFactory(db, { responderPhoneNumber: this.expectedLocationPhoneNumber })
     await db.createLocation(
       'LocationId',
-      this.expectedLocationPhoneNumber,
       1,
       1,
       1,
@@ -37,7 +36,6 @@ describe('BraveAlerterConfigurator.js integration tests: getAlertSession', () =>
       'DoorCoreId',
       'RadarCoreId',
       'XeThru',
-      'alertApiKey',
       true,
       false,
       null,

--- a/test/integration/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
+++ b/test/integration/BraveAlerterConfiguratorTest/getLocationByAlertApiKeyTest.js
@@ -10,9 +10,7 @@ const { clientFactory } = require('../../../testingHelpers')
 
 describe('BraveAlerterConfigurator.js integration tests: getLocationByAlertApiKey', () => {
   beforeEach(async () => {
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.expectedLocationId = 'TEST LOCATION'
     this.apiKey = 'myApiKey'
@@ -42,8 +40,7 @@ describe('BraveAlerterConfigurator.js integration tests: getLocationByAlertApiKe
   })
 
   afterEach(async () => {
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
   })
 
   it('given a API key that matches a single client with a single location should return a BraveAlertLib Location object with the values from that location', async () => {

--- a/test/integration/dashboardTest/submitEditClientTest.js
+++ b/test/integration/dashboardTest/submitEditClientTest.js
@@ -24,9 +24,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     sandbox.spy(helpers, 'log')
     sandbox.spy(helpers, 'logError')
 
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.existingClient = await clientFactory(db)
 
@@ -35,11 +33,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
   afterEach(async () => {
     this.agent.close()
-
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables()
     sandbox.restore()
   })
 

--- a/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/test/integration/dashboardTest/submitEditLocationTest.js
@@ -27,9 +27,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     this.testLocationIdForEdit = 'test1'
 
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.client = await clientFactory(db)
     await db.createLocation(
@@ -58,11 +56,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
   afterEach(async () => {
     sandbox.restore()
-
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables
     this.agent.close()
   })
 

--- a/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/test/integration/dashboardTest/submitEditLocationTest.js
@@ -34,7 +34,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     this.client = await clientFactory(db)
     await db.createLocation(
       this.testLocationIdForEdit,
-      '+14445556789',
       10,
       50,
       100,
@@ -48,7 +47,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       'door_core',
       'radar_core',
       'XeThru',
-      'alertApiKey',
       true,
       false,
       null,
@@ -110,11 +108,9 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
       expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
       expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
-      expect(updatedLocation.responderPhoneNumber).to.equal(this.goodRequest.responderPhoneNumber)
       expect(updatedLocation.fallbackNumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
       expect(updatedLocation.heartbeatAlertRecipients.join(',')).to.equal(this.goodRequest.heartbeatPhones)
       expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
-      expect(updatedLocation.alertApiKey).to.equal(this.goodRequest.alertApiKey)
       expect(updatedLocation.isActive).to.be.true
       expect(updatedLocation.firmwareStateMachine).to.be.false
       expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
@@ -170,133 +166,10 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
       expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
       expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
-      expect(updatedLocation.responderPhoneNumber).to.equal(this.goodRequest.responderPhoneNumber)
       expect(updatedLocation.fallbackNumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
       expect(updatedLocation.heartbeatAlertRecipients.join(',')).to.equal(this.goodRequest.heartbeatPhones)
       expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
-      expect(updatedLocation.alertApiKey).to.equal(this.goodRequest.alertApiKey)
       expect(updatedLocation.isActive).to.be.false
-      expect(updatedLocation.firmwareStateMachine).to.be.false
-      expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
-
-      chai.assert.equal(updatedLocation.movementThreshold, this.goodRequest.movementThreshold)
-      chai.assert.equal(updatedLocation.durationTimer, this.goodRequest.durationTimer)
-      chai.assert.equal(updatedLocation.stillnessTimer, this.goodRequest.stillnessTimer)
-      chai.assert.equal(updatedLocation.initialTimer, this.goodRequest.initialTimer)
-      chai.assert.equal(updatedLocation.reminderTimer, this.goodRequest.reminderTimer)
-      chai.assert.equal(updatedLocation.fallbackTimer, this.goodRequest.fallbackTimer)
-    })
-  })
-
-  describe('for a request that contains all valid non-empty fields but with an empty alertApiKey', () => {
-    beforeEach(async () => {
-      await this.agent.post('/login').send({
-        username: helpers.getEnvVar('WEB_USERNAME'),
-        password: helpers.getEnvVar('PASSWORD'),
-      })
-
-      this.goodRequest = {
-        displayName: 'New Name',
-        doorCoreID: 'new_door_core',
-        radarCoreID: 'new_radar_core',
-        radarType: 'Innosent',
-        responderPhoneNumber: '+12223334567',
-        fallbackPhones: '+13334445678,+12223334444',
-        heartbeatPhones: '+15556667890,+16667778901',
-        twilioPhone: '+11112223456',
-        movementThreshold: 15,
-        durationTimer: 90,
-        stillnessTimer: 10,
-        initialTimer: 9856,
-        reminderTimer: 567849,
-        fallbackTimer: 234567,
-        alertApiKey: '',
-        isActive: 'true',
-        firmwareStateMachine: 'false',
-        sirenParticlId: null,
-        clientId: this.client.id,
-      }
-
-      this.response = await this.agent.post(`/locations/${this.testLocationIdForEdit}`).send(this.goodRequest)
-    })
-
-    it('should return 200', () => {
-      expect(this.response).to.have.status(200)
-    })
-
-    it('should update the location in the database', async () => {
-      const updatedLocation = await db.getLocationData(this.testLocationIdForEdit)
-
-      expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
-      expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
-      expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
-      expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
-      expect(updatedLocation.responderPhoneNumber).to.equal(this.goodRequest.responderPhoneNumber)
-      expect(updatedLocation.fallbackNumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
-      expect(updatedLocation.heartbeatAlertRecipients.join(',')).to.equal(this.goodRequest.heartbeatPhones)
-      expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
-      expect(updatedLocation.alertApiKey).to.be.null
-      expect(updatedLocation.isActive).to.be.true
-      expect(updatedLocation.firmwareStateMachine).to.be.false
-      expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
-
-      chai.assert.equal(updatedLocation.movementThreshold, this.goodRequest.movementThreshold)
-      chai.assert.equal(updatedLocation.durationTimer, this.goodRequest.durationTimer)
-      chai.assert.equal(updatedLocation.stillnessTimer, this.goodRequest.stillnessTimer)
-      chai.assert.equal(updatedLocation.initialTimer, this.goodRequest.initialTimer)
-      chai.assert.equal(updatedLocation.reminderTimer, this.goodRequest.reminderTimer)
-      chai.assert.equal(updatedLocation.fallbackTimer, this.goodRequest.fallbackTimer)
-    })
-  })
-
-  describe('for a request that contains all valid non-empty fields but with an empty phone', () => {
-    beforeEach(async () => {
-      await this.agent.post('/login').send({
-        username: helpers.getEnvVar('WEB_USERNAME'),
-        password: helpers.getEnvVar('PASSWORD'),
-      })
-
-      this.goodRequest = {
-        displayName: 'New Name',
-        doorCoreID: 'new_door_core',
-        radarCoreID: 'new_radar_core',
-        radarType: 'Innosent',
-        responderPhoneNumber: '',
-        fallbackPhones: '+12223334444,+13334445678',
-        heartbeatPhones: '+15556667890,+16667778901',
-        twilioPhone: '+11112223456',
-        movementThreshold: 15,
-        durationTimer: 90,
-        stillnessTimer: 10,
-        initialTimer: 9856,
-        reminderTimer: 567849,
-        fallbackTimer: 234567,
-        alertApiKey: 'newApiKey',
-        isActive: 'true',
-        firmwareStateMachine: 'false',
-        clientId: this.client.id,
-      }
-
-      this.response = await this.agent.post(`/locations/${this.testLocationIdForEdit}`).send(this.goodRequest)
-    })
-
-    it('should return 200', () => {
-      expect(this.response).to.have.status(200)
-    })
-
-    it('should update the location in the database', async () => {
-      const updatedLocation = await db.getLocationData(this.testLocationIdForEdit)
-
-      expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
-      expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
-      expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
-      expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
-      expect(updatedLocation.responderPhoneNumber).to.be.null
-      expect(updatedLocation.fallbackNumbers.join(',')).to.equal(this.goodRequest.fallbackPhones)
-      expect(updatedLocation.heartbeatAlertRecipients.join(',')).to.equal(this.goodRequest.heartbeatPhones)
-      expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
-      expect(updatedLocation.alertApiKey).to.equal(this.goodRequest.alertApiKey)
-      expect(updatedLocation.isActive).to.be.true
       expect(updatedLocation.firmwareStateMachine).to.be.false
       expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
 
@@ -397,7 +270,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.logError).to.have.been.calledWith(
-        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value),responderPhoneNumber/alertApiKey (Invalid value(s))`,
+        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -429,7 +302,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.logError).to.have.been.calledWith(
-        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value),responderPhoneNumber/alertApiKey (Invalid value(s))`,
+        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })

--- a/test/integration/dashboardTest/submitNewClientTest.js
+++ b/test/integration/dashboardTest/submitNewClientTest.js
@@ -41,7 +41,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     sandbox.restore()
   })
 
-  describe('for a request that contains valid non-empty fields', () => {
+  describe('for a request that contains all valid non-empty fields', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
         username: helpers.getEnvVar('WEB_USERNAME'),
@@ -50,9 +50,15 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
       this.displayName = 'myNewClient'
       this.fromPhoneNumber = '+19998887777'
+      this.responderPhoneNumber = '+16665553333'
+      this.responderPushId = 'pushId'
+      this.alertApiKey = 'myApiKey'
       const goodRequest = {
         displayName: this.displayName,
         fromPhoneNumber: this.fromPhoneNumber,
+        responderPhoneNumber: this.responderPhoneNumber,
+        responderPushId: this.responderPushId,
+        alertApiKey: this.alertApiKey,
       }
 
       this.response = await this.agent.post('/clients').send(goodRequest)
@@ -70,12 +76,18 @@ describe('dashboard.js integration tests: submitNewClient', () => {
           return {
             displayName: client.displayName,
             fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumber: client.responderPhoneNumber,
+            responderPushId: client.responderPushId,
+            alertApiKey: client.alertApiKey,
           }
         }),
       ).to.eql([
         {
           displayName: this.displayName,
           fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumber: this.responderPhoneNumber,
+          responderPushId: this.responderPushId,
+          alertApiKey: this.alertApiKey,
         },
       ])
     })
@@ -88,6 +100,9 @@ describe('dashboard.js integration tests: submitNewClient', () => {
       const goodRequest = {
         displayName: 'testDisplayName',
         fromPhoneNumber: '+17778889999',
+        responderPhoneNumber: '+12223334444',
+        responderPushId: 'myResponderPushId',
+        alertApiKey: 'myAlertApiKey',
       }
 
       this.response = await chai.request(server).post('/clients').send(goodRequest)
@@ -103,6 +118,191 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
     it('should log the error', () => {
       expect(helpers.logError).to.have.been.calledWith('Unauthorized')
+    })
+  })
+
+  describe('for a request that contains valid non-empty fields but with no responderPhoneNumber', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPushId = 'pushId'
+      this.alertApiKey = 'myApiKey'
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        responderPushId: this.responderPushId,
+        alertApiKey: this.alertApiKey,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a single client in the database with the given values', async () => {
+      const clients = await db.getClients()
+
+      expect(
+        clients.map(client => {
+          return {
+            displayName: client.displayName,
+            fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumber: client.responderPhoneNumber,
+            responderPushId: client.responderPushId,
+            alertApiKey: client.alertApiKey,
+          }
+        }),
+      ).to.eql([
+        {
+          displayName: this.displayName,
+          fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumber: null,
+          responderPushId: this.responderPushId,
+          alertApiKey: this.alertApiKey,
+        },
+      ])
+    })
+  })
+
+  describe('for a request that contains valid non-empty fields but with no responderPushId', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPhoneNumber = '+16665553333'
+      this.alertApiKey = 'myApiKey'
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        responderPhoneNumber: this.responderPhoneNumber,
+        alertApiKey: this.alertApiKey,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a single client in the database with the given values', async () => {
+      const clients = await db.getClients()
+
+      expect(
+        clients.map(client => {
+          return {
+            displayName: client.displayName,
+            fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumber: client.responderPhoneNumber,
+            responderPushId: client.responderPushId,
+            alertApiKey: client.alertApiKey,
+          }
+        }),
+      ).to.eql([
+        {
+          displayName: this.displayName,
+          fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumber: this.responderPhoneNumber,
+          responderPushId: null,
+          alertApiKey: this.alertApiKey,
+        },
+      ])
+    })
+  })
+
+  describe('for a request that contains valid non-empty fields but with no alertApiKey', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPhoneNumber = '+16665553333'
+      this.responderPushId = 'pushId'
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        responderPhoneNumber: this.responderPhoneNumber,
+        responderPushId: this.responderPushId,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a single client in the database with the given values', async () => {
+      const clients = await db.getClients()
+
+      expect(
+        clients.map(client => {
+          return {
+            displayName: client.displayName,
+            fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumber: client.responderPhoneNumber,
+            responderPushId: client.responderPushId,
+            alertApiKey: client.alertApiKey,
+          }
+        }),
+      ).to.eql([
+        {
+          displayName: this.displayName,
+          fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumber: this.responderPhoneNumber,
+          responderPushId: this.responderPushId,
+          alertApiKey: null,
+        },
+      ])
+    })
+  })
+
+  describe('for a request that contains valid non-empty fields but with no responderPhoneNumber and no responderPushId', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPushId = 'pushId'
+      this.alertApiKey = 'myApiKey'
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        alertApiKey: this.alertApiKey,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+
+    it('should not create a new client in the database', async () => {
+      const clients = await db.getClients()
+
+      expect(clients.length).to.equal(0)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.logError).to.have.been.calledWith('Bad request to /clients: responderPhoneNumber/responderPushId (Invalid value(s))')
     })
   })
 
@@ -125,14 +325,16 @@ describe('dashboard.js integration tests: submitNewClient', () => {
       expect(this.response).to.have.status(400)
     })
 
-    it('should not create a new location in the database', async () => {
+    it('should not create a new client in the database', async () => {
       const clients = await db.getClients()
 
       expect(clients.length).to.equal(0)
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith('Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value)')
+      expect(helpers.logError).to.have.been.calledWith(
+        'Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))',
+      )
     })
   })
 
@@ -157,7 +359,9 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith('Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value)')
+      expect(helpers.logError).to.have.been.calledWith(
+        'Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))',
+      )
     })
   })
 
@@ -173,6 +377,9 @@ describe('dashboard.js integration tests: submitNewClient', () => {
       const duplicateDisplayNameRequest = {
         displayName: this.existingClient.displayName,
         fromPhoneNumber: '+14445556666',
+        responderPhoneNumber: '+19995552222',
+        responderPushId: 'mypushid',
+        alertApiKey: 'myapikey',
       }
 
       this.response = await this.agent.post('/clients').send(duplicateDisplayNameRequest)

--- a/test/integration/dashboardTest/submitNewClientTest.js
+++ b/test/integration/dashboardTest/submitNewClientTest.js
@@ -24,20 +24,14 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     sandbox.spy(helpers, 'log')
     sandbox.spy(helpers, 'logError')
 
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.agent = chai.request.agent(server)
   })
 
   afterEach(async () => {
     this.agent.close()
-
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables()
     sandbox.restore()
   })
 

--- a/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/test/integration/dashboardTest/submitNewLocationTest.js
@@ -43,7 +43,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
     this.agent.close()
   })
 
-  describe('for a request that contains valid non-empty fields', () => {
+  describe('for a request that contains all valid non-empty fields', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
         username: helpers.getEnvVar('WEB_USERNAME'),
@@ -55,20 +55,16 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.doorCoreId = 'door_coreID'
       this.radarCoreId = 'radar_coreID'
       this.radarType = 'XeThru'
-      this.responderPhoneNumber = '+18001231234'
       this.twilioNumber = '+15005550006'
       this.firmwareStateMachine = false
-      this.alertApiKey = 'myApiKey'
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
         doorCoreID: this.doorCoreId,
         radarCoreID: this.radarCoreId,
         radarType: this.radarType,
-        responderPhoneNumber: this.responderPhoneNumber,
         twilioPhone: this.twilioNumber,
         firmwareStateMachine: this.firmwareStateMachine.toString(),
-        alertApiKey: this.alertApiKey,
         clientId: this.client.id,
       }
 
@@ -88,10 +84,8 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreId: newLocation.doorCoreId,
         radarCoreId: newLocation.radarCoreId,
         radarType: newLocation.radarType,
-        responderPhoneNumber: newLocation.responderPhoneNumber,
         twilioNumber: newLocation.twilioNumber,
         firmwareStateMachine: newLocation.firmwareStateMachine,
-        alertApiKey: newLocation.alertApiKey,
         clientId: newLocation.client.id,
       }).to.eql({
         locationid: this.locationid,
@@ -99,10 +93,8 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreId: this.doorCoreId,
         radarCoreId: this.radarCoreId,
         radarType: this.radarType,
-        responderPhoneNumber: this.responderPhoneNumber,
         twilioNumber: this.twilioNumber,
         firmwareStateMachine: this.firmwareStateMachine,
-        alertApiKey: this.alertApiKey,
         clientId: this.client.id,
       })
     })
@@ -124,7 +116,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
         radarType: 'XeThru',
-        responderPhoneNumber: '+18001231234',
         twilioPhone: '+15005550006',
         firmwareStateMachine: 'false',
         clientId: this.clientId,
@@ -156,9 +147,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
         radarType: 'XeThru',
-        responderPhoneNumber: '+18001231234',
         twilioPhone: '+15005550006',
-        alertApiKey: 'myApiKey',
         firmwareStateMachine: 'false',
         clientId: '91ddc8f7-c2e7-490e-bfe9-3d2880a76108',
       }
@@ -179,132 +168,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
     })
   })
 
-  describe('for a request that contains all valid non-empty fields but with no alertApiKey', () => {
-    beforeEach(async () => {
-      await this.agent.post('/login').send({
-        username: helpers.getEnvVar('WEB_USERNAME'),
-        password: helpers.getEnvVar('PASSWORD'),
-      })
-
-      this.locationid = 'unusedID'
-      this.displayName = 'locationName'
-      this.doorCoreId = 'door_coreID'
-      this.radarCoreId = 'radar_coreID'
-      this.radarType = 'XeThru'
-      this.responderPhoneNumber = '+18001231234'
-      this.twilioNumber = '+15005550006'
-      this.firmwareStateMachine = false
-      const goodRequest = {
-        locationid: this.locationid,
-        displayName: this.displayName,
-        doorCoreID: this.doorCoreId,
-        radarCoreID: this.radarCoreId,
-        radarType: this.radarType,
-        responderPhoneNumber: this.responderPhoneNumber,
-        twilioPhone: this.twilioNumber,
-        firmwareStateMachine: this.firmwareStateMachine.toString(),
-        clientId: this.client.id,
-      }
-
-      this.response = await this.agent.post('/locations').send(goodRequest)
-    })
-
-    it('should return 200', () => {
-      expect(this.response).to.have.status(200)
-    })
-
-    it('should create a location in the database with the given values', async () => {
-      const newLocation = await db.getLocationData(this.locationid)
-
-      expect({
-        locationid: newLocation.locationid,
-        displayName: newLocation.displayName,
-        doorCoreId: newLocation.doorCoreId,
-        radarCoreId: newLocation.radarCoreId,
-        radarType: newLocation.radarType,
-        responderPhoneNumber: newLocation.responderPhoneNumber,
-        twilioNumber: newLocation.twilioNumber,
-        firmwareStateMachine: newLocation.firmwareStateMachine,
-        alertApiKey: newLocation.alertApiKey,
-        clientId: newLocation.client.id,
-      }).to.eql({
-        locationid: this.locationid,
-        displayName: this.displayName,
-        doorCoreId: this.doorCoreId,
-        radarCoreId: this.radarCoreId,
-        radarType: this.radarType,
-        responderPhoneNumber: this.responderPhoneNumber,
-        twilioNumber: this.twilioNumber,
-        firmwareStateMachine: this.firmwareStateMachine,
-        alertApiKey: null,
-        clientId: this.client.id,
-      })
-    })
-  })
-
-  describe('for a request that contains all valid non-empty fields but with no responderPhoneNumber', () => {
-    beforeEach(async () => {
-      await this.agent.post('/login').send({
-        username: helpers.getEnvVar('WEB_USERNAME'),
-        password: helpers.getEnvVar('PASSWORD'),
-      })
-
-      this.locationid = 'unusedID'
-      this.displayName = 'locationName'
-      this.doorCoreId = 'door_coreID'
-      this.radarCoreId = 'radar_coreID'
-      this.radarType = 'XeThru'
-      this.twilioNumber = '+15005550006'
-      this.firmwareStateMachine = false
-      this.alertApiKey = 'myApiKey'
-      const goodRequest = {
-        locationid: this.locationid,
-        displayName: this.displayName,
-        doorCoreID: this.doorCoreId,
-        radarCoreID: this.radarCoreId,
-        radarType: this.radarType,
-        twilioPhone: this.twilioNumber,
-        firmwareStateMachine: this.firmwareStateMachine.toString(),
-        alertApiKey: this.alertApiKey,
-        clientId: this.client.id,
-      }
-
-      this.response = await this.agent.post('/locations').send(goodRequest)
-    })
-
-    it('should return 200', () => {
-      expect(this.response).to.have.status(200)
-    })
-
-    it('should create a location in the database with the given values', async () => {
-      const newLocation = await db.getLocationData(this.locationid)
-
-      expect({
-        locationid: newLocation.locationid,
-        displayName: newLocation.displayName,
-        doorCoreId: newLocation.doorCoreId,
-        radarCoreId: newLocation.radarCoreId,
-        radarType: newLocation.radarType,
-        responderPhoneNumber: newLocation.responderPhoneNumber,
-        twilioNumber: newLocation.twilioNumber,
-        firmwareStateMachine: newLocation.firmwareStateMachine,
-        alertApiKey: newLocation.alertApiKey,
-        clientId: newLocation.client.id,
-      }).to.eql({
-        locationid: this.locationid,
-        displayName: this.displayName,
-        doorCoreId: this.doorCoreId,
-        radarCoreId: this.radarCoreId,
-        radarType: this.radarType,
-        responderPhoneNumber: null,
-        twilioNumber: this.twilioNumber,
-        firmwareStateMachine: this.firmwareStateMachine,
-        alertApiKey: this.alertApiKey,
-        clientId: this.client.id,
-      })
-    })
-  })
-
   describe('for a request that contains all valid fields, but empty', () => {
     beforeEach(async () => {
       sandbox.spy(db, 'createLocationFromBrowserForm')
@@ -320,9 +183,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreID: '',
         radarCoreID: '',
         radarType: '',
-        responderPhoneNumber: '',
         twilioPhone: '',
-        alertApiKey: '',
         firmwareStateMachine: '',
         clientId: '',
       }
@@ -340,7 +201,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.logError).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value),responderPhoneNumber/alertApiKey (Invalid value(s))`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -367,7 +228,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.logError).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value),responderPhoneNumber/alertApiKey (Invalid value(s))`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -379,7 +240,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.locationid = 'existingLocationId'
       await db.createLocation(
         this.locationid,
-        '+18881231234',
         40,
         15,
         1,
@@ -393,7 +253,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         'door_coreID',
         'radar_coreID',
         'XeThru',
-        'alertApiKey',
         true,
         false,
         null,
@@ -411,9 +270,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
         radarType: 'XeThru',
-        responderPhoneNumber: '+13338885555',
         twilioPhone: '+15005550006',
-        alertApiKey: 'alertApiKey',
         firmwareStateMachine: 'false',
         clientId: this.client.id,
       }

--- a/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/test/integration/dashboardTest/submitNewLocationTest.js
@@ -24,9 +24,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
     sandbox.spy(helpers, 'log')
     sandbox.spy(helpers, 'logError')
 
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
 
     this.client = await clientFactory(db)
 
@@ -35,11 +33,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
   afterEach(async () => {
     sandbox.restore()
-
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables()
     this.agent.close()
   })
 

--- a/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
+++ b/test/integration/dbTest/getHistoricAlertsByAlertApiKeyTest.js
@@ -20,7 +20,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       const client = await clientFactory(db)
       await db.createLocation(
         'locationid',
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -34,7 +33,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         RADAR_TYPE.INNOSENT,
-        'alertApiKey',
         true,
         false,
         null,
@@ -65,11 +63,10 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       await db.clearLocations()
       await db.clearClients()
 
-      // Insert a single location that has a single session that doesn't match the Alert API Key that we ask for
-      const client = await clientFactory(db)
+      // Insert a single client with a single location that has a single session that doesn't match the Alert API Key that we ask for
+      const client = await clientFactory(db, { alertApiKey: 'not our API key' })
       await db.createLocation(
         'locationid',
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -83,7 +80,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         RADAR_TYPE.INNOSENT,
-        'not our API key',
         true,
         false,
         null,
@@ -94,11 +90,11 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       session.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
       await db.saveSession(session)
 
-      // Insert a single location with no sessions that matches the Alert API Key that we ask for
+      // Insert a single client with a single location with no sessions that matches the Alert API Key that we ask for
       this.alertApiKey = 'alertApiKey'
+      const client2 = await clientFactory(db, { displayName: 'some other name', alertApiKey: this.alertApiKey })
       await db.createLocation(
         'locationid2',
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -112,11 +108,10 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         RADAR_TYPE.INNOSENT,
-        this.alertApiKey,
         true,
         false,
         null,
-        client.id,
+        client2.id,
       )
     })
 
@@ -144,10 +139,9 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       this.displayName = 'displayName'
       const locationid = 'locationid'
       const phonenumber = 'phonenumber'
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: phonenumber, alertApiKey: this.alertApiKey })
       await db.createLocation(
         locationid,
-        phonenumber,
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -161,7 +155,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         RADAR_TYPE.INNOSENT,
-        this.alertApiKey,
         true,
         false,
         null,
@@ -219,10 +212,9 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       // Insert a single location and more than maxHistoricAlerts sessions
       this.alertApiKey = 'alertApiKey'
       const locationid = 'locationid'
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { alertApiKey: this.alertApiKey })
       await db.createLocation(
         locationid,
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -236,7 +228,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         'radarType',
-        this.alertApiKey,
         true,
         false,
         null,
@@ -274,10 +265,9 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       // Insert a single location and maxHistoricAlerts sessions
       this.alertApiKey = 'alertApiKey'
       const locationid = 'locationid'
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { alertApiKey: this.alertApiKey })
       await db.createLocation(
         locationid,
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -291,7 +281,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         'radarType',
-        this.alertApiKey,
         true,
         false,
         null,
@@ -336,10 +325,9 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
       // Insert a single location and one session
       this.alertApiKey = 'alertApiKey'
       const locationid = 'locationid'
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { alertApiKey: this.alertApiKey })
       await db.createLocation(
         locationid,
-        'phonenumber',
         'movementThreshold',
         'stillnessThreshold',
         'durationTimer',
@@ -353,7 +341,6 @@ describe('db.js integration tests: getHistoricAlertsByAlertApiKey', () => {
         'doorCoreId',
         'radarCoreId',
         'radarType',
-        this.alertApiKey,
         true,
         false,
         null,

--- a/test/integration/serverTest.js
+++ b/test/integration/serverTest.js
@@ -136,11 +136,9 @@ describe('Brave Sensor server', () => {
       await db.clearSessions()
       await db.clearLocations()
       await db.clearClients()
-
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -154,7 +152,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'XeThru',
-        'alertApiKey',
         true,
         true,
         null,
@@ -278,10 +275,9 @@ describe('Brave Sensor server', () => {
       await db.clearLocations()
       await db.clearClients()
 
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -295,7 +291,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'XeThru',
-        'alertApiKey',
         true,
         true,
         testSirenId,
@@ -405,10 +400,9 @@ describe('Brave Sensor server', () => {
       await db.clearLocations()
       await db.clearClients()
 
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -422,7 +416,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'XeThru',
-        'alertApiKey',
         true,
         false,
         null,
@@ -528,10 +521,9 @@ describe('Brave Sensor server', () => {
       await db.clearLocations()
       await db.clearClients()
 
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -545,7 +537,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'XeThru',
-        'alertApiKey',
         false,
         false,
         null,
@@ -610,10 +601,9 @@ describe('Brave Sensor server', () => {
       await db.clearLocations()
       await db.clearClients()
 
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -627,7 +617,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'Innosent',
-        'alertApiKey',
         true,
         false,
         null,
@@ -734,10 +723,9 @@ describe('Brave Sensor server', () => {
       await db.clearLocations()
       await db.clearClients
 
-      const client = await clientFactory(db)
+      const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
       await db.createLocation(
         testLocation1Id,
-        testLocation1PhoneNumber,
         MOVEMENT_THRESHOLD,
         STILLNESS_TIMER,
         DURATION_TIMER,
@@ -751,7 +739,6 @@ describe('Brave Sensor server', () => {
         door_coreID,
         radar_coreID,
         'Innosent',
-        'alertApiKey',
         false,
         false,
         null,
@@ -813,10 +800,9 @@ describe('Brave Sensor server', () => {
         await db.clearLocations()
         await db.clearClients()
 
-        const client = await clientFactory(db)
+        const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
         await db.createLocation(
           testLocation1Id,
-          testLocation1PhoneNumber,
           MOVEMENT_THRESHOLD,
           STILLNESS_TIMER,
           DURATION_TIMER,
@@ -830,7 +816,6 @@ describe('Brave Sensor server', () => {
           door_coreID,
           radar_coreID,
           'XeThru',
-          'alertApiKey',
           true,
           false,
           null,
@@ -883,10 +868,9 @@ describe('Brave Sensor server', () => {
         await db.clearLocations()
         await db.clearClients()
 
-        const client = await clientFactory(db)
+        const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
         await db.createLocation(
           testLocation1Id,
-          testLocation1PhoneNumber,
           MOVEMENT_THRESHOLD,
           200,
           400,
@@ -900,7 +884,6 @@ describe('Brave Sensor server', () => {
           door_coreID,
           radar_coreID,
           'XeThru',
-          'alertApiKey',
           true,
           false,
           null,

--- a/test/integration/sirenTest/handleSirenAddressedTest.js
+++ b/test/integration/sirenTest/handleSirenAddressedTest.js
@@ -51,10 +51,9 @@ describe('siren.js integration tests: handleSirenAddressed', () => {
     await db.clearSessions()
     await db.clearLocations()
     await db.clearClients()
-    const client = await clientFactory(db)
+    const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
     await db.createLocation(
       testLocation1Id,
-      testLocation1PhoneNumber,
       MOVEMENT_THRESHOLD,
       STILLNESS_TIMER,
       DURATION_TIMER,
@@ -68,7 +67,6 @@ describe('siren.js integration tests: handleSirenAddressed', () => {
       door_coreID,
       radar_coreID,
       'XeThru',
-      'alertApiKey',
       true,
       true,
       testSirenId,

--- a/test/integration/sirenTest/handleSirenAddressedTest.js
+++ b/test/integration/sirenTest/handleSirenAddressedTest.js
@@ -48,9 +48,8 @@ async function sirenAddressedAlert(coreID) {
 describe('siren.js integration tests: handleSirenAddressed', () => {
   beforeEach(async () => {
     await redis.clearKeys()
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
+
     const client = await clientFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
     await db.createLocation(
       testLocation1Id,
@@ -80,10 +79,7 @@ describe('siren.js integration tests: handleSirenAddressed', () => {
 
   afterEach(async () => {
     await redis.clearKeys()
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables()
     sandbox.restore()
   })
 

--- a/test/integration/sirenTest/handleSirenEscalatedTest.js
+++ b/test/integration/sirenTest/handleSirenEscalatedTest.js
@@ -53,10 +53,10 @@ describe('siren.js integration tests: handleSirenEscalated', () => {
     await db.clearClients()
     const client = await clientFactory(db, {
       fromPhoneNumber: '+12223334444',
+      responderPhoneNumber: testLocation1PhoneNumber,
     })
     await db.createLocation(
       testLocation1Id,
-      testLocation1PhoneNumber,
       MOVEMENT_THRESHOLD,
       STILLNESS_TIMER,
       DURATION_TIMER,
@@ -70,7 +70,6 @@ describe('siren.js integration tests: handleSirenEscalated', () => {
       door_coreID,
       radar_coreID,
       'XeThru',
-      'alertApiKey',
       true,
       true,
       testSirenId,

--- a/test/integration/sirenTest/handleSirenEscalatedTest.js
+++ b/test/integration/sirenTest/handleSirenEscalatedTest.js
@@ -48,9 +48,8 @@ async function sirenEscalatedAlert(coreID) {
 describe('siren.js integration tests: handleSirenEscalated', () => {
   beforeEach(async () => {
     await redis.clearKeys()
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
+    await db.clearTables()
+
     const client = await clientFactory(db, {
       fromPhoneNumber: '+12223334444',
       responderPhoneNumber: testLocation1PhoneNumber,
@@ -83,10 +82,7 @@ describe('siren.js integration tests: handleSirenEscalated', () => {
 
   afterEach(async () => {
     await redis.clearKeys()
-    await db.clearSessions()
-    await db.clearLocations()
-    await db.clearClients()
-
+    await db.clearTables()
     sandbox.restore()
   })
 

--- a/test/unit/BraveAlerterConfiguratorTest/getActiveAlertsByAlertApiKeyTest.js
+++ b/test/unit/BraveAlerterConfiguratorTest/getActiveAlertsByAlertApiKeyTest.js
@@ -1,0 +1,117 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { helpers, ActiveAlert, ALERT_TYPE, CHATBOT_STATE } = require('brave-alert-lib')
+const db = require('../../../db/db')
+const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+
+// Configure Chai
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+describe('BraveAlerterConfigurator.js unit tests: getActiveAlertsByAlertApiKey and createActiveAlertFromRow', () => {
+  beforeEach(() => {
+    this.maxTimeAgoInMillis = 60000
+    sandbox.stub(helpers, 'getEnvVar').withArgs('SESSION_RESET_THRESHOLD').returns(this.maxTimeAgoInMillis)
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    this.braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  it('if there is a single result from db.getActiveAlertsByAlertApiKey, returns an array containing a single ActiveAlert object with the returned data', async () => {
+    const results = {
+      id: 'id',
+      chatbot_state: CHATBOT_STATE.RESPONDING,
+      display_name: 'displayName',
+      alert_type: ALERT_TYPE.SENSOR_DURATION,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+    }
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([results])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([
+      new ActiveAlert(
+        results.id,
+        results.chatbot_state,
+        results.display_name,
+        results.alert_type,
+        ['No One Inside', 'Person responded', 'Overdose', 'None of the above'],
+        results.created_at,
+      ),
+    ])
+  })
+
+  it('if there are multiple results from db.getActiveAlertsByAlertApiKey, returns an array containing the ActiveAlert objects with the returned data', async () => {
+    const results1 = {
+      id: 'id1',
+      chatbot_state: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      display_name: 'displayName1',
+      alert_type: ALERT_TYPE.SENSOR_DURATION,
+      created_at: new Date('2020-01-20T10:10:10.000Z'),
+    }
+    const results2 = {
+      id: 'id2',
+      chatbot_state: CHATBOT_STATE.RESPONDING,
+      display_name: 'displayName2',
+      alert_type: ALERT_TYPE.SENSOR_STILLNESS,
+      created_at: new Date('2019-02-20T09:10:10.000Z'),
+    }
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([results1, results2])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([
+      new ActiveAlert(
+        results1.id,
+        results1.chatbot_state,
+        results1.display_name,
+        results1.alert_type,
+        ['No One Inside', 'Person responded', 'Overdose', 'None of the above'],
+        results1.created_at,
+      ),
+      new ActiveAlert(
+        results2.id,
+        results2.chatbot_state,
+        results2.display_name,
+        results2.alert_type,
+        ['No One Inside', 'Person responded', 'Overdose', 'None of the above'],
+        results2.created_at,
+      ),
+    ])
+  })
+
+  it('if there no results from db.getActiveAlertsByAlertApiKey, returns an empty array', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns([])
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.eql([])
+  })
+
+  it('if db.getActiveAlertsByAlertApiKey returns a non-array, returns null', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns()
+
+    const activeAlerts = await this.braveAlerter.getActiveAlertsByAlertApiKey('alertApiKey')
+
+    expect(activeAlerts).to.be.null
+  })
+
+  it('db.getActiveAlertsByAlertApiKey is called with the given alertApiKey and the SESSION_RESET_THRESHOLD from .env', async () => {
+    sandbox.stub(db, 'getActiveAlertsByAlertApiKey').returns()
+
+    const alertApiKey = 'alertApiKey'
+    await this.braveAlerter.getActiveAlertsByAlertApiKey(alertApiKey)
+
+    expect(db.getActiveAlertsByAlertApiKey).to.be.calledWith(alertApiKey, this.maxTimeAgoInMillis)
+  })
+})

--- a/testingHelpers.js
+++ b/testingHelpers.js
@@ -36,6 +36,9 @@ async function clientFactory(db, overrides) {
   const client = await db.createClient(
     hasOverrides && overrides.displayName || 'factoryClient',
     hasOverrides && overrides.fromPhoneNumber || '+15558881234',
+    hasOverrides && overrides.responderPhoneNumber || '+16665552222',
+    hasOverrides && overrides.responderPushId || 'myPushId',
+    hasOverrides && overrides.alertApiKey || 'alertApiKey',
   )
   return client
 }


### PR DESCRIPTION
Database changes and their corresponding changes in the Dashboard:
- Added `responder_push_id` to the `clients` table
- Moved `responder_push_id` and `alert_api_key` from the `locations` table to the `clients` table

New endpoints from updating `brave-alert-lib`:
- `POST /alert/acknowledgeAlertSession`
- `POST /alert/respondToAlertSession`
- `POST /alert/setIncidentCategory`
- `GET /alert/activeAlerts`

Implementation of two new functions in `braveAlertConfigurator`:
- getAlertSessionBySessionidAndAlertApiKey
- getActiveAlertsByAlertApiKey

Also added a `db.clearTables()` to make sure that I'm consistently cleaning up the tables in the tests

## Test Plan
- :heavy_check_mark: Deploy to `dev.sensors.brave.coop`
- :heavy_check_mark: Run smoketests
- :heavy_check_mark: On the dashboard
   - :heavy_check_mark: Try to add new clients (with valid and invalid values)
   - :heavy_check_mark: Try to add new locations (with valid and invalid values)
   - :heavy_check_mark: Try to edit a client (with valid and invalid values)
   - :heavy_check_mark: Try to edit a location (with valid and invalid values)
- :heavy_check_mark: For the Boron and XeThru sensors in my bathroom, leave the `alert_api_key` and `responder_push_id` as `null` and run through the normal chatbot to make sure that it still behaves as it did before
- :heavy_check_mark: For the Boron and XeThru sensors in my bathroom, add the `alert_api_key` and `responder_push_id` from my Android emulator and run through the Alert App flow
- :heavy_check_mark: Go through the Alert App to make sure that the other API calls still behave as expected
   - :heavy_check_mark: Device designation now includes the `responder_push_id`
   - :heavy_check_mark: Alert History screen is populated with Historic Sensors Alerts
   - :heavy_check_mark: `/alert/location` correctly identifies if it's a Buttons, Sensors, or both system