### PR TITLE
Update brave-alert-lib to send consistent JSON values in the API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -471,9 +471,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -700,8 +700,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#57f7bd3ea8727c971120c104437c896b2f1495cf",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#td-fix-error-message",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#35a46cac42fc746b4ee8a173364ff785c39f090d",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -4239,9 +4239,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.68.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.68.0.tgz",
-      "integrity": "sha512-xVFx/TbibpQtYwkDzuqPS8fsBGg8ZZ2iUtGU68dC9Dv1cngmxePcvxmyFxgPEd6wpnexJHHrCyiSr+LBaBEcDg==",
+      "version": "3.69.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.69.0.tgz",
+      "integrity": "sha512-mm330UFTlFh6GyLZUPVSLO0uVCigW7JdX/wyyV3VuBJ4Z8ie/aNmgztd3xWQr6RBB98gCwJ+UtumqIfixVUm8A==",
       "requires": {
         "axios": "^0.21.1",
         "dayjs": "^1.8.29",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
     "body-parser": "^1.19.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#td-fix-error-message",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.0.0",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",


### PR DESCRIPTION
Also updated the audit-ci.json to ignore a disputed critical security issue:
- Description of the issue: lodash/lodash#5261
- Description of why it's disputed by lodash: https://nvd.nist.gov/vuln/detail/CVE-2021-41720

## Test plan
- :heavy_check_mark: Complete all the tests in https://github.com/bravetechnologycoop/brave-alert-lib/pull/29